### PR TITLE
Add comment and special float tests

### DIFF
--- a/src/lexer.mbt
+++ b/src/lexer.mbt
@@ -181,25 +181,54 @@ fn Lexer::next_token(self : Lexer) -> Token raise {
       if is_numeric(ch) {
         self.read_number(false)
       } else if ch == '-' {
-        // Check if this is a negative number
+        // Check if this is a negative number or special float
         let saved_pos = self.position
         self.advance() // consume the '-'
         match self.peek() {
           Some(next_ch) if is_numeric(next_ch) =>
             // This is a negative number, read it
             self.read_number(true)
+          Some(next_ch) if is_alpha(next_ch) => {
+            let identifier = self.read_identifier()
+            match identifier {
+              "inf" => FloatToken(@strconv.parse_double("-inf"))
+              "nan" => FloatToken(@strconv.parse_double("-nan"))
+              _ => fail("Unexpected identifier after '-': " + identifier)
+            }
+          }
           _ => {
-            // Not a negative number, restore position and error
+            // Not a negative number or special float, restore position and error
             self.position = saved_pos
             fail("Unexpected character: " + Char::to_string(ch))
           }
         }
+      } else if ch == '+' {
+        // Handle optional plus sign for numbers and special floats
+        let saved_pos = self.position
+        self.advance() // consume '+'
+        match self.peek() {
+          Some(next_ch) if is_numeric(next_ch) => self.read_number(false)
+          Some(next_ch) if is_alpha(next_ch) => {
+            let identifier = self.read_identifier()
+            match identifier {
+              "inf" => FloatToken(@strconv.parse_double("+inf"))
+              "nan" => FloatToken(@strconv.parse_double("+nan"))
+              _ => fail("Unexpected identifier after '+': " + identifier)
+            }
+          }
+          _ => {
+            self.position = saved_pos
+            fail("Unexpected character: +")
+          }
+        }
       } else if is_alpha(ch) {
         let identifier = self.read_identifier()
-        // Check for boolean keywords
+        // Check for boolean keywords or special float values
         match identifier {
           "true" => BooleanToken(true)
           "false" => BooleanToken(false)
+          "inf" => FloatToken(@strconv.parse_double("inf"))
+          "nan" => FloatToken(@strconv.parse_double("nan"))
           _ => Identifier(identifier)
         }
       } else {

--- a/src/official_toml_test_suite_test.mbt
+++ b/src/official_toml_test_suite_test.mbt
@@ -382,21 +382,21 @@ test "complex values combination" {
 //   ])
 // }
 
-// TODO: Comments in middle of values not fully tested
-// test "comments" {
-//   let comments_toml =
-//     #|# This is a full-line comment
-//     #|key = "value"  # This is a comment at the end of a line
-//     #|another = "# This is not a comment"
-//     #|
-//   @json.inspect(@toml.parse(comments_toml), content=[
-//     "TomlTable",
-//     {
-//       "key": ["TomlString", "value"],
-//       "another": ["TomlString", "# This is not a comment"]
-//     }
-//   ])
-// }
+///| Test comment handling
+test "comments" {
+  let comments_toml =
+    #|# This is a full-line comment
+    #|key = "value"  # This is a comment at the end of a line
+    #|another = "# This is not a comment"
+    #|
+  @json.inspect(@toml.parse(comments_toml), content=[
+    "TomlTable",
+    {
+      "key": ["TomlString", "value"],
+      "another": ["TomlString", "# This is not a comment"],
+    },
+  ])
+}
 
 // TODO: Integer formats (hex, octal, binary) not yet supported
 // test "integer formats" {
@@ -421,28 +421,28 @@ test "complex values combination" {
 //   ])
 // }
 
-// TODO: Float special values not yet supported
-// test "float special values" {
-//   let float_special_toml =
-//     #|infinity1 = inf
-//     #|infinity2 = +inf
-//     #|infinity3 = -inf
-//     #|not_a_number1 = nan
-//     #|not_a_number2 = +nan
-//     #|not_a_number3 = -nan
-//     #|
-//   @json.inspect(@toml.parse(float_special_toml), content=[
-//     "TomlTable",
-//     {
-//       "infinity1": ["TomlFloat", Double::pos_inf],
-//       "infinity2": ["TomlFloat", Double::pos_inf],
-//       "infinity3": ["TomlFloat", Double::neg_inf],
-//       "not_a_number1": ["TomlFloat", Double::nan],
-//       "not_a_number2": ["TomlFloat", Double::nan],
-//       "not_a_number3": ["TomlFloat", Double::nan]
-//     }
-//   ])
-// }
+///| Test special float values
+test "float special values" {
+  let float_special_toml =
+    #|infinity1 = inf
+    #|infinity2 = +inf
+    #|infinity3 = -inf
+    #|not_a_number1 = nan
+    #|not_a_number2 = +nan
+    #|not_a_number3 = -nan
+    #|
+  @json.inspect(@toml.parse(float_special_toml), content=[
+    "TomlTable",
+    {
+      "infinity1": ["TomlFloat", @strconv.parse_double("inf")],
+      "infinity2": ["TomlFloat", @strconv.parse_double("+inf")],
+      "infinity3": ["TomlFloat", @strconv.parse_double("-inf")],
+      "not_a_number1": ["TomlFloat", @strconv.parse_double("nan")],
+      "not_a_number2": ["TomlFloat", @strconv.parse_double("+nan")],
+      "not_a_number3": ["TomlFloat", @strconv.parse_double("-nan")],
+    },
+  ])
+}
 
 ///| Test for heterogeneous arrays (should be invalid according to TOML spec)
 test "heterogeneous arrays should be invalid" {


### PR DESCRIPTION
## Summary
- add test to ensure parser handles inline and full-line comments
- support `inf`/`nan` float values with sign in lexer and tests

## Testing
- `moon fmt`
- `moon info`
- `moon check`
- `moon test`


------
https://chatgpt.com/codex/tasks/task_e_68906546cd0c8320972aecdb7d1d0969