### PR TITLE
Refactor e2e parse result handling to use try/catch

### DIFF
--- a/e2e/e2e_test.mbt
+++ b/e2e/e2e_test.mbt
@@ -20,22 +20,21 @@ async test "valid toml-test suite" {
         continue
       }
     }
-    let parsed = try? @toml.parse(toml_content)
-    match parsed {
-      Err(e) => {
+    try
+      let value = @toml.parse(toml_content)
+      let actual = to_test_json(value)
+      if !json_equal(actual, expected) {
+        failures.push(
+          "[MISMATCH] \{toml_path}\n    expected: \{expected.stringify()}\n    actual:   \{actual.stringify()}",
+        )
+        failed += 1
+      } else {
+        passed += 1
+      }
+    catch {
+      e => {
         failures.push("[PARSE-ERROR] \{toml_path}: \{e}")
         failed += 1
-      }
-      Ok(value) => {
-        let actual = to_test_json(value)
-        if !json_equal(actual, expected) {
-          failures.push(
-            "[MISMATCH] \{toml_path}\n    expected: \{expected.stringify()}\n    actual:   \{actual.stringify()}",
-          )
-          failed += 1
-        } else {
-          passed += 1
-        }
       }
     }
   }

--- a/e2e/runner.mbt
+++ b/e2e/runner.mbt
@@ -40,19 +40,18 @@ pub fn run_single_valid_test(toml_path : String) -> String? raise @fs.IOError {
   let expected : Json = @json.parse(expected_json_str) catch {
     e => return Some("\{toml_path}: failed to parse expected JSON: \{e}")
   }
-  let parsed = try? @toml.parse(toml_content)
-  match parsed {
-    Err(e) => Some("[PARSE-ERROR] \{toml_path}: \{e}")
-    Ok(value) => {
-      let actual = to_test_json(value)
-      if !json_equal(actual, expected) {
-        Some(
-          "[MISMATCH] \{toml_path}\n    expected: \{expected.stringify()}\n    actual:   \{actual.stringify()}",
-        )
-      } else {
-        None
-      }
+  try
+    let value = @toml.parse(toml_content)
+    let actual = to_test_json(value)
+    if !json_equal(actual, expected) {
+      Some(
+        "[MISMATCH] \{toml_path}\n    expected: \{expected.stringify()}\n    actual:   \{actual.stringify()}",
+      )
+    } else {
+      None
     }
+  catch {
+    e => Some("[PARSE-ERROR] \{toml_path}: \{e}")
   }
 }
 
@@ -66,10 +65,11 @@ pub fn run_single_invalid_test(toml_path : String) -> String? raise @fs.IOError 
     // Non-UTF-8 file: parser would reject this, count as pass
     _ => return None
   }
-  let parsed = try? @toml.parse(toml_content)
-  match parsed {
-    Ok(_) => Some("[PASS-BUT-SHOULD-FAIL] \{toml_path}")
-    Err(_) => None
+  try
+    let _ = @toml.parse(toml_content)
+    Some("[PASS-BUT-SHOULD-FAIL] \{toml_path}")
+  catch {
+    _ => None
   }
 }
 


### PR DESCRIPTION
### Motivation
- Replace `try?` + `match Ok/Err` patterns with direct `try ... catch` to simplify control flow and make parse error handling explicit in e2e test helpers.

### Description
- Update `run_single_valid_test` and `run_single_invalid_test` in `e2e/runner.mbt` to wrap `@toml.parse(...)` with `try ... catch` while preserving existing mismatch and parse-error messages.
- Update the valid-suite loop in `e2e/e2e_test.mbt` to use `try ... catch` around each parse and keep pass/fail counters and failure reporting unchanged.

### Testing
- Attempted to run `moon fmt`, but `moon` is not available in the environment (`moon: command not found`), so no automated formatting or `moon`-based tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e6fd7284832091101706fa7709c2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
