### PR TITLE
fix: remove unnecessary view conversions

### DIFF
--- a/e2e/runner.mbt
+++ b/e2e/runner.mbt
@@ -62,7 +62,7 @@ pub fn run_single_valid_test(toml_path : String) -> String? raise @fs.IOError {
 pub fn run_single_invalid_test(toml_path : String) -> String? raise @fs.IOError {
   let toml_bytes = @fs.read_file_to_bytes(toml_path)
   // Try decoding as UTF-8, skip non-UTF-8 files (they should fail anyway)
-  let toml_content = @utf8.decode(toml_bytes[:]) catch {
+  let toml_content = @utf8.decode(toml_bytes) catch {
     // Non-UTF-8 file: parser would reject this, count as pass
     _ => return None
   }

--- a/internal/qc_model/gen_test.mbt
+++ b/internal/qc_model/gen_test.mbt
@@ -394,7 +394,7 @@ fn table_value_gen(size : Int) -> @qc.Gen[@qc_model.SimpleValue] {
   @qc.int_range(0, max_fields + 1).bind(fn(field_count) {
     simple_entry_gen(next_size)
     .array_with_size(field_count)
-    .fmap(fn(entries) { @qc_model.STable(Map::from_array(entries[:])) })
+    .fmap(fn(entries) { @qc_model.STable(Map::from_array(entries)) })
   })
 }
 
@@ -416,7 +416,7 @@ fn simple_document_gen() -> @qc.Gen[@qc_model.SimpleDocument] {
       simple_entry_gen(size)
       .array_with_size(field_count)
       .fmap(fn(entries) {
-        @qc_model.SimpleDocument::{ fields: Map::from_array(entries[:]) }
+        @qc_model.SimpleDocument::{ fields: Map::from_array(entries) }
       })
     })
   })

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -46,7 +46,7 @@ pub fn SimpleValue::to_toml(self : SimpleValue) -> @toml.TomlValue {
     STable(fields) =>
       @toml.TomlTable(
         Map::from_array(
-          fields.to_array().map(entry => (entry.0, entry.1.to_toml()))[:],
+          fields.to_array().map(entry => (entry.0, entry.1.to_toml())),
         ),
       )
   }
@@ -56,7 +56,7 @@ pub fn SimpleValue::to_toml(self : SimpleValue) -> @toml.TomlValue {
 pub fn SimpleDocument::to_toml(self : SimpleDocument) -> @toml.TomlValue {
   @toml.TomlTable(
     Map::from_array(
-      self.fields.to_array().map(entry => (entry.0, entry.1.to_toml()))[:],
+      self.fields.to_array().map(entry => (entry.0, entry.1.to_toml())),
     ),
   )
 }
@@ -119,26 +119,26 @@ pub fn SimpleValue::from_toml(value : @toml.TomlValue) -> SimpleValue? {
       match values {
         [] => Some(SEmptyArray)
         [@toml.TomlDateTime(_), ..] =>
-          collect_toml_array(values[:], project_datetime).map(items => {
+          collect_toml_array(values, project_datetime).map(items => {
             SDateTimeArray(items)
           })
         [@toml.TomlString(_), ..] =>
-          collect_toml_array(values[:], project_string).map(items => {
+          collect_toml_array(values, project_string).map(items => {
             SStringArray(items)
           })
         [@toml.TomlInteger(_), ..] =>
-          collect_toml_array(values[:], project_integer).map(items => {
+          collect_toml_array(values, project_integer).map(items => {
             SIntegerArray(items)
           })
         [@toml.TomlBoolean(_), ..] =>
-          collect_toml_array(values[:], project_boolean).map(items => {
+          collect_toml_array(values, project_boolean).map(items => {
             SBooleanArray(items)
           })
         _ => None
       }
     @toml.TomlTable(fields) =>
-      simple_table_entries_from_toml(fields.to_array()[:]).map(entries => {
-        STable(Map::from_array(entries[:]))
+      simple_table_entries_from_toml(fields.to_array()).map(entries => {
+        STable(Map::from_array(entries))
       })
     _ => None
   }
@@ -163,8 +163,8 @@ fn simple_table_entries_from_toml(
 pub fn SimpleDocument::from_toml(value : @toml.TomlValue) -> SimpleDocument? {
   match value {
     @toml.TomlTable(fields) =>
-      simple_table_entries_from_toml(fields.to_array()[:]).map(entries => {
-        fields: Map::from_array(entries[:]),
+      simple_table_entries_from_toml(fields.to_array()).map(entries => {
+        fields: Map::from_array(entries),
       })
     _ => None
   }

--- a/internal/qc_model/shrink_test.mbt
+++ b/internal/qc_model/shrink_test.mbt
@@ -45,7 +45,7 @@ fn shrink_simple_value(
       })
     STable(fields) =>
       shrink_table_entries(fields.to_array()).map(fn(next_entries) {
-        @qc_model.STable(Map::from_array(next_entries[:]))
+        @qc_model.STable(Map::from_array(next_entries))
       })
   }
 }


### PR DESCRIPTION
## Summary
- Removes 14 unnecessary `[:]` view conversions that MoonBit inserts automatically when the expected type is a view
- Clears all `unnecessary_view_op` (0075) warnings from `moon check`

## Test plan
- [x] `moon check` reports 0 warnings
- [x] `moon test` — 383/383 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
