### PR TITLE
refactor: use list comprehension instead of map/each

### DIFF
--- a/e2e/convert.mbt
+++ b/e2e/convert.mbt
@@ -18,12 +18,11 @@ pub fn to_test_json(value : @toml.TomlValue) -> Json {
         _ => typed_value("date-local", s)
       }
     }
-    @toml.TomlArray(arr) => Json::array(arr.map(to_test_json))
-    @toml.TomlTable(table) => {
-      let obj : Map[String, Json] = {}
-      table.each(fn(k, v) { obj[k] = to_test_json(v) })
-      Json::object(obj)
-    }
+    @toml.TomlArray(arr) => Json::array([ for v in arr => to_test_json(v) ])
+    @toml.TomlTable(table) =>
+      Json::object(
+        Map::from_array([ for k, v in table => (k, to_test_json(v)) ]),
+      )
   }
 }
 

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -35,19 +35,17 @@ pub fn SimpleValue::to_toml(self : SimpleValue) -> @toml.TomlValue {
     SBoolean(b) => @toml.TomlBoolean(b)
     SDateTime(value) => @toml.TomlDateTime(value)
     SDateTimeArray(values) =>
-      @toml.TomlArray(values.map(value => @toml.TomlDateTime(value)))
+      @toml.TomlArray([ for v in values => @toml.TomlDateTime(v) ])
     SEmptyArray => @toml.TomlArray([])
     SStringArray(values) =>
-      @toml.TomlArray(values.map(v => @toml.TomlString(v)))
+      @toml.TomlArray([ for v in values => @toml.TomlString(v) ])
     SIntegerArray(values) =>
-      @toml.TomlArray(values.map(v => @toml.TomlInteger(v)))
+      @toml.TomlArray([ for v in values => @toml.TomlInteger(v) ])
     SBooleanArray(values) =>
-      @toml.TomlArray(values.map(v => @toml.TomlBoolean(v)))
+      @toml.TomlArray([ for v in values => @toml.TomlBoolean(v) ])
     STable(fields) =>
       @toml.TomlTable(
-        Map::from_array(
-          fields.to_array().map(entry => (entry.0, entry.1.to_toml())),
-        ),
+        Map::from_array([ for k, v in fields => (k, v.to_toml()) ]),
       )
   }
 }
@@ -55,9 +53,7 @@ pub fn SimpleValue::to_toml(self : SimpleValue) -> @toml.TomlValue {
 ///|
 pub fn SimpleDocument::to_toml(self : SimpleDocument) -> @toml.TomlValue {
   @toml.TomlTable(
-    Map::from_array(
-      self.fields.to_array().map(entry => (entry.0, entry.1.to_toml())),
-    ),
+    Map::from_array([ for k, v in self.fields => (k, v.to_toml()) ]),
   )
 }
 


### PR DESCRIPTION
## Summary
- Rewrites array and map transformations with MoonBit's list comprehension syntax (`[for v in xs => f(v)]`, `[for k, v in map => (k, g(v))]`)
- Drops intermediate `.to_array()` calls and tuple-field access (`entry.0`, `entry.1`) by iterating maps directly
- Replaces mutation-based `Map.each` building (`obj[k] = ...`) with a single `Map::from_array` expression

## Test plan
- [x] `moon check` — 0 warnings
- [x] `moon test` — 383/383 tests pass
- [x] `moon fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
