### PR TITLE
refactor: use array literals in tests and demo

### DIFF
--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -13,10 +13,11 @@ fn main {
 
   // Demo 2: Array example
   println("\n--- Array Example ---")
-  let arr = Array::new()
-  arr.push(@toml.TomlInteger(1L))
-  arr.push(@toml.TomlInteger(2L))
-  arr.push(@toml.TomlInteger(3L))
+  let arr = [
+    @toml.TomlInteger(1L),
+    @toml.TomlInteger(2L),
+    @toml.TomlInteger(3L),
+  ]
   let array_val = @toml.TomlArray(arr)
   println("Array value: \{array_val}")
 

--- a/coverage_improvement_comprehensive_test.mbt
+++ b/coverage_improvement_comprehensive_test.mbt
@@ -336,10 +336,11 @@ test "main_function_components_coverage" {
   )
 
   // Create and manipulate arrays like in main
-  let arr = Array::new()
-  arr.push(@toml.TomlInteger(1L))
-  arr.push(@toml.TomlInteger(2L))
-  arr.push(@toml.TomlInteger(3L))
+  let arr = [
+    @toml.TomlInteger(1L),
+    @toml.TomlInteger(2L),
+    @toml.TomlInteger(3L),
+  ]
   let array_val = @toml.TomlArray(arr)
   debug_inspect(
     array_val.to_string(),

--- a/datetime_test.mbt
+++ b/datetime_test.mbt
@@ -103,16 +103,11 @@ test "toml spec local time examples" {
 /// Test datetime arrays (homogeneous and mixed)
 test "datetime arrays validation" {
   // Array of same datetime type (should be valid in TOML)
-  let offset_array = Array::new()
-  offset_array.push(
+  let offset_array = [
     @toml.TomlDateTime(@tokenize.OffsetDateTime("2023-01-01T00:00:00Z")),
-  )
-  offset_array.push(
     @toml.TomlDateTime(@tokenize.OffsetDateTime("2023-01-02T00:00:00Z")),
-  )
-  offset_array.push(
     @toml.TomlDateTime(@tokenize.OffsetDateTime("2023-01-03T00:00:00Z")),
-  )
+  ]
   let offset_arr_value = @toml.TomlArray(offset_array)
   let offset_str = offset_arr_value.to_string()
   debug_inspect(offset_str.contains("2023-01-01T00:00:00Z"), content="true")
@@ -120,10 +115,11 @@ test "datetime arrays validation" {
   debug_inspect(offset_str.contains("2023-01-03T00:00:00Z"), content="true")
 
   // Array of local dates
-  let date_array = Array::new()
-  date_array.push(@toml.TomlDateTime(@tokenize.LocalDate("2023-01-01")))
-  date_array.push(@toml.TomlDateTime(@tokenize.LocalDate("2023-01-02")))
-  date_array.push(@toml.TomlDateTime(@tokenize.LocalDate("2023-01-03")))
+  let date_array = [
+    @toml.TomlDateTime(@tokenize.LocalDate("2023-01-01")),
+    @toml.TomlDateTime(@tokenize.LocalDate("2023-01-02")),
+    @toml.TomlDateTime(@tokenize.LocalDate("2023-01-03")),
+  ]
   let date_arr_value = @toml.TomlArray(date_array)
   let date_str = date_arr_value.to_string()
   debug_inspect(date_str.contains("2023-01-01"), content="true")
@@ -409,16 +405,11 @@ test "realistic datetime scenarios" {
   config["backup_time"] = @toml.TomlDateTime(@tokenize.LocalTime("03:00:00"))
 
   // Array of maintenance windows
-  let maintenance_windows = Array::new()
-  maintenance_windows.push(
+  let maintenance_windows = [
     @toml.TomlDateTime(@tokenize.LocalDateTime("2023-06-20T02:00:00")),
-  )
-  maintenance_windows.push(
     @toml.TomlDateTime(@tokenize.LocalDateTime("2023-07-20T02:00:00")),
-  )
-  maintenance_windows.push(
     @toml.TomlDateTime(@tokenize.LocalDateTime("2023-08-20T02:00:00")),
-  )
+  ]
   config["maintenance_schedule"] = @toml.TomlArray(maintenance_windows)
   let config_value = @toml.TomlTable(config)
   let config_str = config_value.to_string()

--- a/toml_test.mbt
+++ b/toml_test.mbt
@@ -52,10 +52,11 @@ test "toml boolean value" {
 
 ///|
 test "toml array value" {
-  let arr = Array::new()
-  arr.push(@toml.TomlInteger(1L))
-  arr.push(@toml.TomlInteger(2L))
-  arr.push(@toml.TomlInteger(3L))
+  let arr = [
+    @toml.TomlInteger(1L),
+    @toml.TomlInteger(2L),
+    @toml.TomlInteger(3L),
+  ]
   let value = @toml.TomlArray(arr)
   debug_inspect(
     value.to_string(),
@@ -248,11 +249,12 @@ test "toml datetime equality" {
 ///|
 /// Tests for mixed datetime array
 test "toml mixed datetime array" {
-  let arr = Array::new()
-  arr.push(@toml.TomlDateTime(OffsetDateTime("1979-05-27T07:32:00Z")))
-  arr.push(@toml.TomlDateTime(LocalDateTime("1979-05-27T07:32:00")))
-  arr.push(@toml.TomlDateTime(LocalDate("1979-05-27")))
-  arr.push(@toml.TomlDateTime(LocalTime("07:32:00")))
+  let arr = [
+    @toml.TomlDateTime(OffsetDateTime("1979-05-27T07:32:00Z")),
+    @toml.TomlDateTime(LocalDateTime("1979-05-27T07:32:00")),
+    @toml.TomlDateTime(LocalDate("1979-05-27")),
+    @toml.TomlDateTime(LocalTime("07:32:00")),
+  ]
   let value = @toml.TomlArray(arr)
   let str_repr = value.to_string()
 
@@ -334,11 +336,12 @@ test "toml datetime edge cases" {
 ///|
 /// Tests for parser creation  
 test "parser creation" {
-  let tokens = Array::new()
   let loc = @tokenize.default_loc()
-  tokens.push(@tokenize.Identifier("key", loc~))
-  tokens.push(@tokenize.Equals(loc~))
-  tokens.push(@tokenize.StringToken("value", loc~, multiline=false))
+  let tokens = [
+    @tokenize.Identifier("key", loc~),
+    @tokenize.Equals(loc~),
+    @tokenize.StringToken("value", loc~, multiline=false),
+  ]
   let parser = @toml.Parser::new(tokens)
   debug_inspect(parser.position, content="0")
   debug_inspect(parser.tokens.length(), content="3")
@@ -380,43 +383,43 @@ test "datetime token creation" {
 /// Tests for array homogeneity validation
 test "array homogeneity validation" {
   // Homogeneous arrays (should be valid)
-  let int_array = Array::new()
-  int_array.push(@toml.TomlInteger(1L))
-  int_array.push(@toml.TomlInteger(2L))
-  int_array.push(@toml.TomlInteger(3L))
+  let int_array = [
+    @toml.TomlInteger(1L),
+    @toml.TomlInteger(2L),
+    @toml.TomlInteger(3L),
+  ]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(int_array),
     content="true",
   )
-  let string_array = Array::new()
-  string_array.push(@toml.TomlString("a"))
-  string_array.push(@toml.TomlString("b"))
-  string_array.push(@toml.TomlString("c"))
+  let string_array = [
+    @toml.TomlString("a"),
+    @toml.TomlString("b"),
+    @toml.TomlString("c"),
+  ]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(string_array),
     content="true",
   )
-  let datetime_array = Array::new()
-  datetime_array.push(
+  let datetime_array = [
     @toml.TomlDateTime(OffsetDateTime("2023-01-01T00:00:00Z")),
-  )
-  datetime_array.push(@toml.TomlDateTime(LocalDateTime("2023-01-02T00:00:00")))
-  datetime_array.push(@toml.TomlDateTime(LocalDate("2023-01-03")))
+    @toml.TomlDateTime(LocalDateTime("2023-01-02T00:00:00")),
+    @toml.TomlDateTime(LocalDate("2023-01-03")),
+  ]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(datetime_array),
     content="true",
   )
 
   // Empty array (should be valid)
-  let empty_array = Array::new()
+  let empty_array : Array[@toml.TomlValue] = []
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(empty_array),
     content="true",
   )
 
   // Single element array (should be valid)
-  let single_array = Array::new()
-  single_array.push(@toml.TomlBoolean(true))
+  let single_array = [@toml.TomlBoolean(true)]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(single_array),
     content="true",
@@ -427,28 +430,28 @@ test "array homogeneity validation" {
 /// Tests for heterogeneous arrays (should be invalid)
 test "array heterogeneity detection" {
   // Mixed types (should be invalid)
-  let mixed_array = Array::new()
-  mixed_array.push(@toml.TomlInteger(1L))
-  mixed_array.push(@toml.TomlString("hello"))
-  mixed_array.push(@toml.TomlBoolean(true))
+  let mixed_array = [
+    @toml.TomlInteger(1L),
+    @toml.TomlString("hello"),
+    @toml.TomlBoolean(true),
+  ]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(mixed_array),
     content="false",
   )
 
   // Numbers with different types (should be invalid in TOML)
-  let mixed_numbers = Array::new()
-  mixed_numbers.push(@toml.TomlInteger(1L))
-  mixed_numbers.push(@toml.TomlFloat(2.5))
+  let mixed_numbers = [@toml.TomlInteger(1L), @toml.TomlFloat(2.5)]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(mixed_numbers),
     content="false",
   )
 
   // Mixed datetime and string (should be invalid)
-  let mixed_dt_string = Array::new()
-  mixed_dt_string.push(@toml.TomlDateTime(LocalDate("2023-01-01")))
-  mixed_dt_string.push(@toml.TomlString("not a date"))
+  let mixed_dt_string = [
+    @toml.TomlDateTime(LocalDate("2023-01-01")),
+    @toml.TomlString("not a date"),
+  ]
   debug_inspect(
     @toml.TomlValue::is_homogeneous_array(mixed_dt_string),
     content="false",
@@ -459,24 +462,18 @@ test "array heterogeneity detection" {
 /// Tests for TomlValue validation
 test "toml value validation" {
   // Valid homogeneous array
-  let valid_array = Array::new()
-  valid_array.push(@toml.TomlInteger(1L))
-  valid_array.push(@toml.TomlInteger(2L))
+  let valid_array = [@toml.TomlInteger(1L), @toml.TomlInteger(2L)]
   let valid_toml_array = @toml.TomlArray(valid_array)
   debug_inspect(valid_toml_array.validate(), content="true")
 
   // Invalid heterogeneous array
-  let invalid_array = Array::new()
-  invalid_array.push(@toml.TomlInteger(1L))
-  invalid_array.push(@toml.TomlString("mixed"))
+  let invalid_array = [@toml.TomlInteger(1L), @toml.TomlString("mixed")]
   let invalid_toml_array = @toml.TomlArray(invalid_array)
   debug_inspect(invalid_toml_array.validate(), content="false")
 
   // Valid nested structure
   let valid_table : Map[String, @toml.TomlValue] = Map::new()
-  let nested_array = Array::new()
-  nested_array.push(@toml.TomlString("item1"))
-  nested_array.push(@toml.TomlString("item2"))
+  let nested_array = [@toml.TomlString("item1"), @toml.TomlString("item2")]
   valid_table["items"] = @toml.TomlArray(nested_array)
   valid_table["count"] = @toml.TomlInteger(2L)
   let valid_nested = @toml.TomlTable(valid_table)
@@ -484,9 +481,10 @@ test "toml value validation" {
 
   // Invalid nested structure (contains invalid array)
   let invalid_table : Map[String, @toml.TomlValue] = Map::new()
-  let bad_nested_array = Array::new()
-  bad_nested_array.push(@toml.TomlString("item1"))
-  bad_nested_array.push(@toml.TomlInteger(42L)) // Mixed types
+  let bad_nested_array = [
+    @toml.TomlString("item1"),
+    @toml.TomlInteger(42L), // Mixed types
+  ]
   invalid_table["items"] = @toml.TomlArray(bad_nested_array)
   invalid_table["count"] = @toml.TomlInteger(2L)
   let invalid_nested = @toml.TomlTable(invalid_table)


### PR DESCRIPTION
## Summary
- Replaces \`Array::new()\` + repeated \`.push(...)\` patterns with inline array literals \`[a, b, c]\` across tests and the demo in \`cmd/main\`
- Reduces ~20 imperative push sites with no behavior change
- Follow-up to PR #75 — list comprehension didn't fit these sites cleanly (no iteration/transform), but array literals still cut the imperative noise

## Test plan
- [x] \`moon check\` — 0 warnings
- [x] \`moon test\` — 383/383 tests pass
- [x] \`moon fmt\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
