### PR TITLE
fix(tokenize): add `with longest` to lexmatch

### DIFF
--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -647,7 +647,7 @@ fn Lexer::read_binary_number(self : Lexer) -> Int64 raise {
 /// Check if the current input matches a datetime pattern without consuming characters
 fn Lexer::is_datetime_pattern(self : Lexer) -> Bool {
   // Check for datetime patterns using regex
-  lexmatch self.view() {
+  lexmatch self.view() with longest {
     (
       "[0-9]{2}:[0-9]{2}"
       "(:[0-9]{2})?(\.[0-9]+)?",
@@ -675,12 +675,12 @@ fn Lexer::read_datetime_with_loc(
   self : Lexer,
   start_pos : @lexer.Position,
 ) -> Token raise {
-  // Try patterns in order - no need for `with longest` since patterns are
-  // naturally disambiguated by structure:
+  // Try patterns in order. Patterns are naturally disambiguated by
+  // structure, so first-match and longest-match produce the same result:
   // - LocalTime: HH:MM:SS (starts with 2 digits, has colons)
   // - Date-based: YYYY-MM-DD (starts with 4 digits)
   //   - Check what follows T to determine: LocalDate, LocalDateTime, or OffsetDateTime
-  lexmatch self.view() {
+  lexmatch self.view() with longest {
     // LocalTime: HH:MM[:SS[.fff]] - must check first (2-digit start vs 4-digit)
     (("[0-9]{2}:[0-9]{2}" "(:[0-9]{2})?(\.[0-9]+)?") as time, rest) => {
       self.update_view(rest)


### PR DESCRIPTION
## Summary
- Adds `with longest` to the two `lexmatch` blocks in `internal/tokenize/tokenize.mbt`, silencing the deprecation: *\"Using \`lexmatch\` with first-match semantics is deprecated. Add \`with longest\` if longest-match semantics are intended.\"*
- The alternatives in both blocks are naturally disambiguated by structure (2-digit colon vs 4-digit dash), so first-match and longest-match produce identical results — no behavior change.

This PR is intentionally focused on a single warning category. The remaining `StringView.to_string()` and `inspect`/`Debug` warnings are addressed in separate PRs.

## Test plan
- [x] `moon check`: the 2 `lexmatch` warnings are gone.
- [x] `moon test`: 396/396 pass (regression-free; the snapshot in `coverage_improvement_test.mbt` references a tokenizer source line, so the comment edit was sized to preserve the line number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
