### PR TITLE
test(lexer): use `debug_inspect` for Char? snapshots

### DIFF
--- a/lexer/README.mbt.md
+++ b/lexer/README.mbt.md
@@ -167,9 +167,9 @@ test "core methods example" {
 ///|
 test "character access example" {
   let lexer = Lexer::new("Hello")
-  inspect(lexer.peek(), content="Some('H')")
+  debug_inspect(lexer.peek(), content="Some('H')")
   lexer.advance()
-  inspect(lexer.peek(), content="Some('e')")
+  debug_inspect(lexer.peek(), content="Some('e')")
 }
 ```
 
@@ -185,7 +185,7 @@ test "string views example" {
     [.. "😈x", .. rest] => lexer.update_view(rest)
     _ => ()
   }
-  inspect(lexer.peek(), content="Some('中')")
+  debug_inspect(lexer.peek(), content="Some('中')")
 }
 ```
 
@@ -196,7 +196,7 @@ test "string views example" {
 test "whitespace handling example" {
   let lexer = Lexer::new("  \t\rHello, world!")
   lexer.skip_whitespace()
-  inspect(lexer.peek(), content="Some('H')")
+  debug_inspect(lexer.peek(), content="Some('H')")
 }
 ```
 
@@ -233,7 +233,7 @@ test "unicode support example" {
   inspect(lexer.get_position(), content="0")
   lexer.advance() // Correctly advances past the 2-byte emoji
   inspect(lexer.get_position(), content="2") // 2 bytes for emoji
-  inspect(lexer.peek(), content="Some('x')")
+  debug_inspect(lexer.peek(), content="Some('x')")
 }
 ```
 

--- a/lexer/lexer.mbt
+++ b/lexer/lexer.mbt
@@ -230,7 +230,7 @@ test "skip whitespace with position tracking" {
   let lexer = Lexer::new("  \t\rH")
   lexer.skip_whitespace()
   inspect(lexer.get_loc().column, content="5") // moved past 4 whitespace chars
-  inspect(lexer.peek(), content="Some('H')")
+  debug_inspect(lexer.peek(), content="Some('H')")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Switches the five `inspect(lexer.peek(), ...)` snapshots in `lexer/lexer.mbt` and `lexer/README.mbt.md` to `debug_inspect(...)`, dispatching on the `Debug` trait instead of the deprecated `Show for X?` impl.
- Resolves the warning: *\"Use Debug instead of Show for debugging purposes.\"*
- The `Debug` representation for `Char?` is identical to `Show` (`Some('H')`), so no snapshot strings need to change.

This PR is intentionally focused on a single warning category. The remaining `StringView.to_string()` and `lexmatch with longest` warnings are addressed in separate PRs.

## Test plan
- [x] `moon check`: the 5 *\"Use Debug instead of Show\"* warnings are gone.
- [x] `moon test`: 396/396 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
