### PR TITLE
refactor(e2e): drop `.to_owned()` where interpolation suffices

### DIFF
--- a/e2e/convert.mbt
+++ b/e2e/convert.mbt
@@ -104,9 +104,7 @@ fn normalize_time_seconds(s : String) -> String {
   }
   if colons == 1 {
     // HH:MM without seconds, insert :00 after MM (at time_end)
-    let before = s[:time_end].to_owned()
-    let after = s[time_end:].to_owned()
-    "\{before}:00\{after}"
+    "\{s[:time_end]}:00\{s[time_end:]}"
   } else {
     s
   }

--- a/e2e/e2e_test.mbt
+++ b/e2e/e2e_test.mbt
@@ -7,7 +7,7 @@ async test "valid toml-test suite" {
   let mut failed = 0
   let failures : Array[String] = []
   for toml_path in files {
-    let json_path = toml_path[:toml_path.length() - 5].to_owned() + ".json"
+    let json_path = "\{toml_path[:toml_path.length() - 5]}.json"
     if !@fs.path_exists(json_path) {
       continue
     }

--- a/e2e/runner.mbt
+++ b/e2e/runner.mbt
@@ -31,7 +31,7 @@ pub fn collect_toml_files(
 /// Run a single valid test: parse .toml, convert to test JSON, compare with .json.
 /// Returns None on success, Some(error_message) on failure.
 pub fn run_single_valid_test(toml_path : String) -> String? raise @fs.IOError {
-  let json_path = toml_path[:toml_path.length() - 5].to_owned() + ".json"
+  let json_path = "\{toml_path[:toml_path.length() - 5]}.json"
   if !@fs.path_exists(json_path) {
     return None
   }
@@ -166,13 +166,9 @@ fn normalize_frac_seconds(s : String) -> String {
   }
   if trimmed_end == dot_pos + 1 {
     // All fractional digits were zeros — remove the dot too
-    let before = s[:dot_pos].to_owned()
-    let after = s[frac_end:].to_owned()
-    "\{before}\{after}"
+    "\{s[:dot_pos]}\{s[frac_end:]}"
   } else if trimmed_end < frac_end {
-    let before = s[:trimmed_end].to_owned()
-    let after = s[frac_end:].to_owned()
-    "\{before}\{after}"
+    "\{s[:trimmed_end]}\{s[frac_end:]}"
   } else {
     s
   }


### PR DESCRIPTION
## Summary
- Six call sites in `e2e/` were doing `view.to_owned() + suffix` or `let s = view.to_owned(); "\{s}…"`. Format strings already accept `StringView` via `Show::output`, so the intermediate allocation can be elided.
- Three files touched: `e2e/convert.mbt`, `e2e/e2e_test.mbt`, `e2e/runner.mbt`. 5 insertions, 11 deletions.
- Behavior is unchanged. The remaining `.to_owned()` sites in `internal/tokenize` and `parser.mbt` are intentionally kept — they feed typed token fields (`LocalTime(String)`, `LocalDate(String)`), validation helpers, or `Array[String]` storage, all of which need an owned `String`.

## Codex review
Asked `codex review` whether this is safe; verbatim verdict:

> No findings. Interpolation uses `Show::to_string`, and `StringView`'s `to_string` returns the raw owned view contents; only `Show::output` quotes/escapes. Performance is neutral-to-better depending on lowering, and slicing/empty/long-view edge cases are unchanged from the previous code.

## Test plan
- [x] `moon check --deny-warn` clean.
- [x] `moon test`: 396/396 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/toml-parser/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
