### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -307,7 +307,7 @@ let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
 
 ///|
 // Empty map
-let empty : Map[String, Int] = Map::new()
+let empty : Map[String, Int] = Map([])
 
 ///|
 /// From array of pairs

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -209,7 +209,7 @@ test {
   // Error handling with try-catch
   let invalid_toml = "invalid = [unclosed"
   let config = @toml.parse(invalid_toml) catch {
-    _ => @toml.TomlTable(Map::new()) // Return default value on error
+    _ => @toml.TomlTable(Map([])) // Return default value on error
   }
   guard config is TomlTable(table) else { fail("Expected table") }
   assert_eq(table.length(), 0) // Empty table from error handler

--- a/coverage_improvement_comprehensive_test.mbt
+++ b/coverage_improvement_comprehensive_test.mbt
@@ -140,8 +140,8 @@ test "homogeneous_array_with_floats" {
 ///|
 /// Test homogeneous array with TomlTable
 test "homogeneous_array_with_tables" {
-  let table1 = Map::new()
-  let table2 = Map::new()
+  let table1 = Map([])
+  let table2 = Map([])
   let arr = [@toml.TomlTable(table1), @toml.TomlTable(table2)]
   let result = @toml.TomlValue::is_homogeneous_array(arr)
   debug_inspect(result, content="true")
@@ -158,7 +158,7 @@ test "homogeneous_array_type_check_boolean" {
 ///|
 /// Test homogeneous array type checking with TomlTable vs other
 test "homogeneous_array_type_check_table_vs_other" {
-  let table = Map::new()
+  let table = Map([])
   let arr = [@toml.TomlTable(table), @toml.TomlInteger(42L)]
   let result = @toml.TomlValue::is_homogeneous_array(arr)
   debug_inspect(result, content="false")

--- a/datetime_test.mbt
+++ b/datetime_test.mbt
@@ -130,7 +130,7 @@ test "datetime arrays validation" {
 ///|
 /// Test datetime in complex nested structures
 test "datetime in nested structures" {
-  let event_table : Map[String, @toml.TomlValue] = Map::new()
+  let event_table : Map[String, @toml.TomlValue] = Map([])
   event_table["name"] = @toml.TomlString("Conference 2023")
   event_table["start_date"] = @toml.TomlDateTime(
     @tokenize.LocalDate("2023-06-15"),
@@ -142,13 +142,13 @@ test "datetime in nested structures" {
     @tokenize.LocalDateTime("2023-06-17T17:00:00"),
   )
   let sessions = Array::new()
-  let session1 : Map[String, @toml.TomlValue] = Map::new()
+  let session1 : Map[String, @toml.TomlValue] = Map([])
   session1["title"] = @toml.TomlString("Opening Keynote")
   session1["scheduled_at"] = @toml.TomlDateTime(
     @tokenize.OffsetDateTime("2023-06-15T09:00:00+00:00"),
   )
   sessions.push(@toml.TomlTable(session1))
-  let session2 : Map[String, @toml.TomlValue] = Map::new()
+  let session2 : Map[String, @toml.TomlValue] = Map([])
   session2["title"] = @toml.TomlString("Technical Workshop")
   session2["scheduled_at"] = @toml.TomlDateTime(
     @tokenize.OffsetDateTime("2023-06-15T14:00:00+00:00"),
@@ -384,7 +384,7 @@ test "timezone boundary cases" {
 /// Test realistic application scenarios
 test "realistic datetime scenarios" {
   // Application configuration with various datetime needs
-  let config : Map[String, @toml.TomlValue] = Map::new()
+  let config : Map[String, @toml.TomlValue] = Map([])
 
   // Deployment timestamp (offset datetime)
   config["deployed_at"] = @toml.TomlDateTime(

--- a/toml_test.mbt
+++ b/toml_test.mbt
@@ -68,7 +68,7 @@ test "toml array value" {
 
 ///|
 test "toml table value" {
-  let table : Map[String, @toml.TomlValue] = Map::new()
+  let table : Map[String, @toml.TomlValue] = Map([])
   table["key1"] = @toml.TomlString("value1")
   table["key2"] = @toml.TomlInteger(42L)
   let value = @toml.TomlTable(table)
@@ -268,7 +268,7 @@ test "toml mixed datetime array" {
 ///|
 /// Tests for datetime in table
 test "toml datetime in table" {
-  let table : Map[String, @toml.TomlValue] = Map::new()
+  let table : Map[String, @toml.TomlValue] = Map([])
   table["created_at"] = @toml.TomlDateTime(
     OffsetDateTime("2023-01-01T00:00:00Z"),
   )
@@ -472,7 +472,7 @@ test "toml value validation" {
   debug_inspect(invalid_toml_array.validate(), content="false")
 
   // Valid nested structure
-  let valid_table : Map[String, @toml.TomlValue] = Map::new()
+  let valid_table : Map[String, @toml.TomlValue] = Map([])
   let nested_array = [@toml.TomlString("item1"), @toml.TomlString("item2")]
   valid_table["items"] = @toml.TomlArray(nested_array)
   valid_table["count"] = @toml.TomlInteger(2L)
@@ -480,7 +480,7 @@ test "toml value validation" {
   debug_inspect(valid_nested.validate(), content="true")
 
   // Invalid nested structure (contains invalid array)
-  let invalid_table : Map[String, @toml.TomlValue] = Map::new()
+  let invalid_table : Map[String, @toml.TomlValue] = Map([])
   let bad_nested_array = [
     @toml.TomlString("item1"),
     @toml.TomlInteger(42L), // Mixed types

--- a/toml_to_string_test.mbt
+++ b/toml_to_string_test.mbt
@@ -323,7 +323,7 @@ test "serialize table with special key names" {
 ///|
 test "serialize empty structures" {
   inspect(@toml.TomlArray([]), content="[]")
-  inspect(@toml.TomlTable(Map::new()), content="")
+  inspect(@toml.TomlTable(Map([])), content="")
 }
 
 ///|

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -32,7 +32,7 @@ fn create_nested_table(
         if current_table.contains("\u0000__inline__") {
           raise InlineTableImmutable(key)
         }
-        let new_table = Map::new()
+        let new_table = Map([])
         current_table[key] = TomlTable(new_table)
         current_table = new_table
       }
@@ -133,7 +133,7 @@ fn create_array_of_tables(
         }
       Some(value) => raise ExpectedTable(key, value)
       None => {
-        let new_table = Map::new()
+        let new_table = Map([])
         current_table[key] = TomlTable(new_table)
         current_table = new_table
       }
@@ -264,7 +264,7 @@ test "create_array_of_tables - nested path creation" {
 ///|
 test "create_array_of_tables - mixed with regular tables" {
   // Test array of tables mixed with regular tables
-  let root_table : Map[String, TomlValue] = Map::new()
+  let root_table : Map[String, TomlValue] = Map([])
 
   // First create a regular table structure
   set_dotted_key_value(root_table, ["owner", "name"], TomlString("Tom"))
@@ -301,7 +301,7 @@ test "create_array_of_tables - mixed with regular tables" {
 #skip("error message is not correct")
 test "create_array_of_tables - path conflicts with non-table" {
   // Test error when intermediate path conflicts with non-table value
-  let root_table : Map[String, TomlValue] = Map::new()
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Set a string value at "products"
   root_table["products"] = TomlString("not a table")
@@ -321,7 +321,7 @@ test "create_array_of_tables - path conflicts with non-table" {
 #skip("error message is not correct")
 test "create_array_of_tables - final key conflicts with non-array" {
   // Test error when final key exists but is not an array
-  let root_table : Map[String, TomlValue] = Map::new()
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create a regular table at servers.alpha
   set_dotted_key_value(
@@ -343,7 +343,7 @@ test "create_array_of_tables - final key conflicts with non-array" {
 ///|
 test "create_array_of_tables - multiple nested arrays" {
   // Test creating multiple different arrays of tables
-  let root_table : Map[String, TomlValue] = Map::new()
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create first [[fruits]]
   let fruit1 = create_array_of_tables(root_table, ["fruits"])
@@ -384,7 +384,7 @@ test "create_array_of_tables - multiple nested arrays" {
 ///|
 test "create_array_of_tables - empty table in array" {
   // Test that empty tables are correctly added to arrays
-  let root_table : Map[String, TomlValue] = Map::new()
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create empty table in array
   let _empty_table1 = create_array_of_tables(root_table, ["empty", "tables"])
@@ -457,7 +457,7 @@ fn set_dotted_key_value(
       Some(value) => raise ExpectedTable(key, value)
       None => {
         // Create new nested table
-        let new_table = Map::new()
+        let new_table = Map([])
         if mark_implicit {
           new_table["\u0000__defined__"] = TomlBoolean(true)
         }
@@ -478,7 +478,7 @@ fn set_dotted_key_value(
 ///|
 test "set dotted key value - simple key" {
   // Test setting a simple key (path length 1)
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["name"], TomlString("Alice"))
   debug_inspect(
     table,
@@ -491,7 +491,7 @@ test "set dotted key value - simple key" {
 ///|
 test "set dotted key value - nested keys creating tables" {
   // Test creating nested tables automatically
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["server", "host"], TomlString("localhost"))
   set_dotted_key_value(table, ["server", "port"], TomlInteger(8080))
   debug_inspect(
@@ -505,7 +505,7 @@ test "set dotted key value - nested keys creating tables" {
 ///|
 test "set dotted key value - deep nesting" {
   // Test deep nested table creation
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(
     table,
     ["a", "b", "c", "d", "e"],
@@ -522,7 +522,7 @@ test "set dotted key value - deep nesting" {
 ///|
 test "set dotted key value - multiple values same nested table" {
   // Test adding multiple values to the same nested table
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
 
   // Add multiple values at different levels
   set_dotted_key_value(table, ["database", "server"], TomlString("postgres"))
@@ -557,7 +557,7 @@ test "set dotted key value - multiple values same nested table" {
 
 ///|
 test "set dotted key value - reject duplicate key" {
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["config", "timeout"], TomlInteger(30))
   // Duplicate key should be rejected
   let result = try? set_dotted_key_value(
@@ -571,7 +571,7 @@ test "set dotted key value - reject duplicate key" {
 ///|
 test "set dotted key value - add to existing table" {
   // Test adding values to an already existing table
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
 
   // Create initial structure
   set_dotted_key_value(table, ["app", "name"], TomlString("MyApp"))
@@ -623,7 +623,7 @@ test "set dotted key value - conflict with non-table value" {
 ///|
 test "set dotted key value - mixed types in path" {
   // Test with different value types at different levels
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(
     table,
     ["root", "array"],
@@ -661,7 +661,7 @@ test "set dotted key value - mixed types in path" {
 #skip("empty path edge case to fix later")
 test "set dotted key value - empty path edge case" {
   // Test with empty path (edge case)
-  let table : Map[String, TomlValue] = Map::new()
+  let table : Map[String, TomlValue] = Map([])
 
   // Set a value first
   set_dotted_key_value(table, ["key"], TomlString("value"))


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.

## Note
- Local test output includes existing fixture diagnostics and a dependency C compiler warning, but the command exited successfully and warning cleanup check is clean.
