### PR TITLE
Extend <+ sugar to tokenize and TableConflicts

### DIFF
--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -52,24 +52,24 @@ pub(all) enum TomlDateTime {
 pub impl Show for TomlDateTime with output(self, logger) {
   match self {
     OffsetDateTime(s) => {
-      logger.write_string("OffsetDateTime(\"")
+      logger <+ "OffsetDateTime(\""
       logger.write_string(s)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     LocalDateTime(s) => {
-      logger.write_string("LocalDateTime(\"")
+      logger <+ "LocalDateTime(\""
       logger.write_string(s)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     LocalDate(s) => {
-      logger.write_string("LocalDate(\"")
+      logger <+ "LocalDate(\""
       logger.write_string(s)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     LocalTime(s) => {
-      logger.write_string("LocalTime(\"")
+      logger <+ "LocalTime(\""
       logger.write_string(s)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
   }
 }

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -296,7 +296,7 @@ fn @lexer.Lexer::read_multiline_basic_string(
     match view {
       [.. "\"\"\"\"\"", .. rest] => {
         // 5 quotes: 2 content quotes + closing triple quotes
-        sb.write_string("\"\"")
+        sb <+ "\"\""
         self.update_view(rest)
         break sb.to_string()
       }
@@ -461,7 +461,7 @@ fn @lexer.Lexer::read_multiline_literal_string(
     match view {
       [.. "'''''", .. rest] => {
         // 5 quotes: 2 content quotes + closing triple quotes
-        sb.write_string("''")
+        sb <+ "''"
         self.update_view(rest)
         break sb.to_string()
       }
@@ -477,7 +477,7 @@ fn @lexer.Lexer::read_multiline_literal_string(
         break sb.to_string()
       }
       [.. "\r\n", .. rest] => {
-        sb.write_string("\r\n")
+        sb <+ "\r\n"
         self.update_view(rest)
         self.new_line()
         continue self.view()

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -54,28 +54,28 @@ priv suberror TableConflicts {
 impl Show for TableConflicts with output(self, logger) {
   match self {
     ExpectedTable(key, value) => {
-      logger.write_string("ExpectedTable(\"")
+      logger <+ "ExpectedTable(\""
       logger.write_string(key)
-      logger.write_string("\", \"")
+      logger <+ "\", \""
       logger.write_string(value.type_name())
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     ExpectedArray(key, value) => {
-      logger.write_string("ExpectedArray(\"")
+      logger <+ "ExpectedArray(\""
       logger.write_string(key)
-      logger.write_string("\", \"")
+      logger <+ "\", \""
       logger.write_string(value.type_name())
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     DuplicateKey(key) => {
-      logger.write_string("DuplicateKey(\"")
+      logger <+ "DuplicateKey(\""
       logger.write_string(key)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
     InlineTableImmutable(key) => {
-      logger.write_string("InlineTableImmutable(\"")
+      logger <+ "InlineTableImmutable(\""
       logger.write_string(key)
-      logger.write_string("\")")
+      logger <+ "\")"
     }
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #84. Applies `<+` to the remaining literal `write_string` calls in:
- `internal/tokenize/token.mbt` (TomlDateTime Show)
- `internal/tokenize/tokenize.mbt` (multi-line string close markers)
- `toml_utils.mbt` (TableConflicts Show)

String-valued sub-expressions (`key`, `value.type_name()`, the captured datetime text) stay on `.write_string()` — `\{string}` inside a `<+` template is miscompiled on current nightly (quotes via `Show.output`).

## Test plan
- [x] `moon check --deny-warn` clean on stable
- [x] `moon test` — 396/396 pass on stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)