### PR TITLE
Apply <+ $| to more Show impls and the e2e summary writes

### DIFF
--- a/e2e/e2e_test.mbt
+++ b/e2e/e2e_test.mbt
@@ -44,9 +44,9 @@ async test "valid toml-test suite" {
   )
   if failed > 0 {
     let msg = StringBuilder::new()
-    msg.write_string("\{failed} of \{passed + failed} valid tests failed:\n")
+    msg <+ "\{failed} of \{passed + failed} valid tests failed:\n"
     for f in failures {
-      msg.write_string("  \{f}\n")
+      msg <+ "  \{f}\n"
     }
     let msg = msg.to_string()
     println(msg)
@@ -76,9 +76,9 @@ async test "invalid toml-test suite" {
   )
   if failed > 0 {
     let msg = StringBuilder::new()
-    msg.write_string("\{failed} of \{passed + failed} invalid tests failed:\n")
+    msg <+ "\{failed} of \{passed + failed} invalid tests failed:\n"
     for f in failures {
-      msg.write_string("  \{f}\n")
+      msg <+ "  \{f}\n"
     }
     let msg = msg.to_string()
     println(msg)

--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -51,26 +51,22 @@ pub(all) enum TomlDateTime {
 /// Show impl for TomlDateTime - provides human-readable format
 pub impl Show for TomlDateTime with output(self, logger) {
   match self {
-    OffsetDateTime(s) => {
-      logger <+ "OffsetDateTime(\""
-      logger.write_string(s)
-      logger <+ "\")"
-    }
-    LocalDateTime(s) => {
-      logger <+ "LocalDateTime(\""
-      logger.write_string(s)
-      logger <+ "\")"
-    }
-    LocalDate(s) => {
-      logger <+ "LocalDate(\""
-      logger.write_string(s)
-      logger <+ "\")"
-    }
-    LocalTime(s) => {
-      logger <+ "LocalTime(\""
-      logger.write_string(s)
-      logger <+ "\")"
-    }
+    OffsetDateTime(s) =>
+      logger
+        <+
+        $|OffsetDateTime("\{s}")
+    LocalDateTime(s) =>
+      logger
+        <+
+        $|LocalDateTime("\{s}")
+    LocalDate(s) =>
+      logger
+        <+
+        $|LocalDate("\{s}")
+    LocalTime(s) =>
+      logger
+        <+
+        $|LocalTime("\{s}")
   }
 }
 

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -53,30 +53,22 @@ priv suberror TableConflicts {
 /// Show impl for error messages
 impl Show for TableConflicts with output(self, logger) {
   match self {
-    ExpectedTable(key, value) => {
-      logger <+ "ExpectedTable(\""
-      logger.write_string(key)
-      logger <+ "\", \""
-      logger.write_string(value.type_name())
-      logger <+ "\")"
-    }
-    ExpectedArray(key, value) => {
-      logger <+ "ExpectedArray(\""
-      logger.write_string(key)
-      logger <+ "\", \""
-      logger.write_string(value.type_name())
-      logger <+ "\")"
-    }
-    DuplicateKey(key) => {
-      logger <+ "DuplicateKey(\""
-      logger.write_string(key)
-      logger <+ "\")"
-    }
-    InlineTableImmutable(key) => {
-      logger <+ "InlineTableImmutable(\""
-      logger.write_string(key)
-      logger <+ "\")"
-    }
+    ExpectedTable(key, value) =>
+      logger
+        <+
+        $|ExpectedTable("\{key}", "\{value.type_name()}")
+    ExpectedArray(key, value) =>
+      logger
+        <+
+        $|ExpectedArray("\{key}", "\{value.type_name()}")
+    DuplicateKey(key) =>
+      logger
+        <+
+        $|DuplicateKey("\{key}")
+    InlineTableImmutable(key) =>
+      logger
+        <+
+        $|InlineTableImmutable("\{key}")
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #85. Two more places where `<+` lands cleanly:

1. **`TableConflicts` and `TomlDateTime` Show impls** — each arm used to be a 3- or 5-step `write_string` sequence (literal prefix, key, separator, value, suffix). With `$|` template interpolation, each collapses to a single line, e.g.
   ```moonbit
   ExpectedTable(key, value) =>
     logger <+ $|ExpectedTable("\{key}", "\{value.type_name()}")
   ```
2. **`e2e/e2e_test.mbt` failure-summary writes** — the four `msg.write_string("\{failed} of …")` / `msg.write_string("  \{f}\n")` calls become `msg <+ "…"`.

## Notes
- `\{string}` inside a `<+` template still routes through `Show.output` on current nightly (quotes the string). Once the nightly fix lands these all match exactly; on stable they already do. The diagnostic e2e writes only run on failure and aren't asserted, so output-format drift on nightly is harmless.

## Test plan
- [x] `moon check --deny-warn` clean on stable
- [x] `moon test` — 396/396 pass on stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)