### PR TITLE
[codex] Bump toml version to 0.2.3

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/toml"
 
-version = "0.2.2"
+version = "0.2.3"
 
 import {
   "bobzhang/lexer@0.1.3",


### PR DESCRIPTION
## Summary
- bump `bobzhang/toml` from `0.2.2` to `0.2.3` for republish

## Validation
- `moon fmt`
- `moon check`
- `moon check --deny-warn`
- `moon test`
- `moon info`
- `moon publish --dry-run` validated `bobzhang/toml` `0.2.3` and returned server status `202 Accepted`, then the CLI exited `255` after printing `Dry run completed successfully. No changes were made.`