### PR TITLE
[codex] Add TOML CLI cram tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,13 @@ jobs:
       
       - name: moon test (unit tests)
         run: moon test .
-        
+
+      - name: moon cram (native CLI)
+        if: matrix.channel == 'nightly'
+        run: |
+          moon build --target native --release
+          TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
+
       # - name: moon test
       #   run: moon test --enable-coverage
 

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -65,14 +65,31 @@ Add this parser to your MoonBit project:
 moon add bobzhang/toml
 ```
 
-Then add it directly to your `moon.mod.json`:
+Then add it directly to your `moon.mod`:
 
-```json
-{
-  "deps": {
-    "bobzhang/toml": "^0.2.0"
-  }
+```moonbit nocheck
+import {
+  "bobzhang/toml@0.2.3",
 }
+```
+
+## Command-Line Usage
+
+The module includes a native `toml` CLI in `cmd/main` for validating and
+normalizing TOML files:
+
+```bash
+moon run --target native cmd/main -- --help
+moon run --target native cmd/main -- check config.toml
+moon run --target native cmd/main -- format config.toml
+```
+
+For release-style CLI testing, build the native binary and run the Moon Cram
+transcript tests:
+
+```bash
+moon build --target native --release
+TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
 ```
 
 ## Quick Start

--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -1,58 +1,91 @@
 ///|
+let version : String = "0.2.3"
+
+///|
+let usage : String =
+  #|toml 0.2.3
+  #|
+  #|Usage:
+  #|  toml format <file>
+  #|  toml check <file>
+  #|  toml <file>
+  #|
+  #|Commands:
+  #|  format <file>  Parse TOML and print normalized TOML.
+  #|  check <file>   Validate TOML without printing parsed output.
+  #|
+  #|Options:
+  #|  -h, --help     Show this help.
+  #|  --version      Show the CLI version.
+
+///|
 fn main {
-  println("TOML Parser Demo")
-
-  // Demo 1: Basic value types
-  println("\n--- Basic Value Types ---")
-  let str_val = @toml.TomlString("Hello, TOML!")
-  let int_val = @toml.TomlInteger(42L)
-  let bool_val = @toml.TomlBoolean(true)
-  println("String value: \{str_val}")
-  println("Integer value: \{int_val}")
-  println("Boolean value: \{bool_val}")
-
-  // Demo 2: Array example
-  println("\n--- Array Example ---")
-  let arr = [@toml.TomlInteger(1L), TomlInteger(2L), TomlInteger(3L)]
-  let array_val = @toml.TomlArray(arr)
-  println("Array value: \{array_val}")
-
-  // Demo 3: Parse simple TOML
-  println("\n--- Parse Simple TOML ---")
-  let toml_input = "name = \"John Doe\"\nage = 30\nenabled = true"
-  println("Input TOML:")
-  println(toml_input)
-  try {
-    let result = @toml.parse(toml_input)
-    println("\nParsed result:")
-    println(result.to_string())
-  } catch {
-    msg => println("Parse error: \{msg}")
+  let code = run(@env.args()[1:])
+  if code != 0 {
+    @sys.exit(code)
   }
+}
 
-  // Demo 4: Parse with array
-  println("\n--- Parse TOML with Array ---")
-  let toml_array = "numbers = [1, 2, 3, 4, 5]"
-  println("Input TOML:")
-  println(toml_array)
-  try {
-    let result = @toml.parse(toml_array)
-    println("\nParsed result:")
-    println(result.to_string())
-  } catch {
-    msg => println("Parse error: \{msg}")
+///|
+fn run(args : ArrayView[String]) -> Int {
+  match args {
+    [] | ["help"] | ["-h"] | ["--help"] => {
+      println(usage)
+      0
+    }
+    ["--version"] | ["version"] => {
+      println("toml \{version}")
+      0
+    }
+    ["format"] => usage_error("missing file for `format`")
+    ["check"] => usage_error("missing file for `check`")
+    ["format", path] | [path] => format_file(path)
+    ["check", path] => check_file(path)
+    [command, ..] =>
+      usage_error("unknown command or extra arguments: `\{command}`")
   }
+}
 
-  // Demo 5: Parse with inline table
-  println("\n--- Parse TOML with Inline Table ---")
-  let toml_table = "person = {name = \"Alice\", age = 25}"
-  println("Input TOML:")
-  println(toml_table)
-  try {
-    let result = @toml.parse(toml_table)
-    println("\nParsed result:")
-    println(result.to_string())
-  } catch {
-    msg => println("Parse error: \{msg}")
+///|
+fn format_file(path : String) -> Int {
+  let source = @fs.read_file_to_string(path) catch {
+    err => {
+      println("error: failed to read \{path}: \{err}")
+      return 1
+    }
   }
+  let value = @toml.parse(source) catch {
+    err => {
+      println("error: failed to parse \{path}: \{err}")
+      return 1
+    }
+  }
+  println(value.to_string())
+  0
+}
+
+///|
+fn check_file(path : String) -> Int {
+  let source = @fs.read_file_to_string(path) catch {
+    err => {
+      println("error: failed to read \{path}: \{err}")
+      return 1
+    }
+  }
+  let _ = @toml.parse(source) catch {
+    err => {
+      println("error: failed to parse \{path}: \{err}")
+      return 1
+    }
+  }
+  println("\{path}: OK")
+  0
+}
+
+///|
+fn usage_error(message : String) -> Int {
+  println("error: \{message}")
+  println("")
+  println(usage)
+  2
 }

--- a/cmd/main/moon.pkg
+++ b/cmd/main/moon.pkg
@@ -1,5 +1,8 @@
 import {
   "bobzhang/toml",
+  "moonbitlang/core/env",
+  "moonbitlang/x/fs",
+  "moonbitlang/x/sys",
 }
 
 options(

--- a/moon.mod
+++ b/moon.mod
@@ -5,6 +5,7 @@ version = "0.2.3"
 import {
   "bobzhang/lexer@0.1.3",
   "moonbitlang/quickcheck@0.11.2",
+  "moonbitlang/x@0.4.41",
 }
 
 readme = "README.md"

--- a/tests/cram/toml_cli.md
+++ b/tests/cram/toml_cli.md
@@ -1,0 +1,75 @@
+# TOML CLI Cram Tests
+
+These Moon Cram tests document the native `toml` executable. Set `TOML_CLI` to
+the native release binary before running them:
+
+```bash
+moon build --target native --release
+TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
+```
+
+## Help And Version
+
+```mooncram
+$ "$TOML_CLI" --version
+toml 0.2.3
+```
+
+```mooncram
+$ "$TOML_CLI" --help
+toml 0.2.3
+
+Usage:
+  toml format <file>
+  toml check <file>
+  toml <file>
+
+Commands:
+  format <file>  Parse TOML and print normalized TOML.
+  check <file>   Validate TOML without printing parsed output.
+
+Options:
+  -h, --help     Show this help.
+  --version      Show the CLI version.
+```
+
+## Format A File
+
+```mooncram
+$ cat > sample.toml <<'EOF'
+> title = "MoonBit"
+> ports = [8000, 8001]
+> [server]
+> enabled = true
+> EOF
+> "$TOML_CLI" format sample.toml
+title = "MoonBit"
+
+ports = [8000, 8001]
+
+[server]
+enabled = true
+
+```
+
+## Check A File
+
+```mooncram
+$ cat > valid.toml <<'EOF'
+> package = "toml"
+> version = "0.2.3"
+> EOF
+> "$TOML_CLI" check valid.toml
+valid.toml: OK
+```
+
+## Report Parse Errors
+
+```mooncram
+$ cat > invalid.toml <<'EOF'
+> key =
+> EOF
+> "$TOML_CLI" check invalid.toml
+error: failed to parse invalid.toml: Failure(parser.mbt:*@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 6 }, end: { line: 2, column: 1 } }) (glob)
+[1]
+```

--- a/toml_to_string_test.mbt
+++ b/toml_to_string_test.mbt
@@ -17,6 +17,28 @@ test "serialize string with control characters" {
 }
 
 ///|
+test "roundtrip string with escaped control characters" {
+  let original = @toml.TomlTable(
+    Map::from_array([
+      ("nul", TomlString("\u0000")),
+      ("bell", TomlString("\u0007")),
+      ("delete", TomlString("\u007F")),
+    ]),
+  )
+  let serialized = original.to_string()
+  inspect(
+    serialized,
+    content=(
+      #|nul = "\u0000"
+      #|bell = "\u0007"
+      #|delete = "\u007F"
+      #|
+    ),
+  )
+  assert_eq(@toml.parse(serialized), original)
+}
+
+///|
 test "serialize integers" {
   inspect(@toml.TomlInteger(42L), content="42")
   inspect(@toml.TomlInteger(-1234L), content="-1234")


### PR DESCRIPTION
## Summary
- replace the demo `cmd/main` executable with a small native TOML CLI
- support `--help`, `--version`, `format <file>`, `check <file>`, and file shorthand formatting
- document CLI usage in the README and add Moon Cram transcript tests
- run the cram transcript in CI only for the nightly matrix entry because stable may not have `moon cram`

## Validation
- `moon fmt`
- `moon check --deny-warn`
- `moon test`
- `moon info`
- `moon build --target native --release`
- `TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram --no-color`