### PR TITLE
[codex] Parse TOML CLI with argparse

### DIFF
--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -2,21 +2,44 @@
 let version : String = "0.2.3"
 
 ///|
-let usage : String =
-  #|toml 0.2.3
-  #|
-  #|Usage:
-  #|  toml format <file>
-  #|  toml check <file>
-  #|  toml <file>
-  #|
-  #|Commands:
-  #|  format <file>  Parse TOML and print normalized TOML.
-  #|  check <file>   Validate TOML without printing parsed output.
-  #|
-  #|Options:
-  #|  -h, --help     Show this help.
-  #|  --version      Show the CLI version.
+fn toml_command() -> @argparse.Command {
+  @argparse.Command(
+    "toml",
+    about="Parse, validate, and format TOML files.",
+    version~,
+    arg_required_else_help=true,
+    positionals=[
+      @argparse.PositionArg(
+        "file",
+        about="Parse TOML and print normalized TOML.",
+      ),
+    ],
+    subcommands=[
+      @argparse.Command(
+        "format",
+        about="Parse TOML and print normalized TOML.",
+        positionals=[
+          @argparse.PositionArg(
+            "file",
+            about="TOML file to format.",
+            num_args=@argparse.ValueRange::single(),
+          ),
+        ],
+      ),
+      @argparse.Command(
+        "check",
+        about="Validate TOML without printing parsed output.",
+        positionals=[
+          @argparse.PositionArg(
+            "file",
+            about="TOML file to validate.",
+            num_args=@argparse.ValueRange::single(),
+          ),
+        ],
+      ),
+    ],
+  )
+}
 
 ///|
 fn main {
@@ -28,21 +51,28 @@ fn main {
 
 ///|
 fn run(args : ArrayView[String]) -> Int {
-  match args {
-    [] | ["help"] | ["-h"] | ["--help"] => {
-      println(usage)
-      0
+  let matches = @argparse.parse(toml_command(), argv=args, env={}) catch {
+    err => {
+      println(err)
+      return 2
     }
-    ["--version"] | ["version"] => {
-      println("toml \{version}")
-      0
+  }
+  match matches.subcommand {
+    Some(("format", child)) => dispatch_file(child, format_file)
+    Some(("check", child)) => dispatch_file(child, check_file)
+    Some((name, _)) => {
+      println("error: unsupported command `\{name}`")
+      2
     }
-    ["format"] => usage_error("missing file for `format`")
-    ["check"] => usage_error("missing file for `check`")
-    ["format", path] | [path] => format_file(path)
-    ["check", path] => check_file(path)
-    [command, ..] =>
-      usage_error("unknown command or extra arguments: `\{command}`")
+    None => dispatch_file(matches, format_file)
+  }
+}
+
+///|
+fn dispatch_file(matches : @argparse.Matches, action : (String) -> Int) -> Int {
+  match matches.values.get("file") {
+    Some([path]) => action(path)
+    _ => 2
   }
 }
 
@@ -80,12 +110,4 @@ fn check_file(path : String) -> Int {
   }
   println("\{path}: OK")
   0
-}
-
-///|
-fn usage_error(message : String) -> Int {
-  println("error: \{message}")
-  println("")
-  println(usage)
-  2
 }

--- a/cmd/main/moon.pkg
+++ b/cmd/main/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/toml",
+  "moonbitlang/core/argparse",
   "moonbitlang/core/env",
   "moonbitlang/x/fs",
   "moonbitlang/x/sys",

--- a/tests/cram/toml_cli.md
+++ b/tests/cram/toml_cli.md
@@ -12,25 +12,45 @@ TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon
 
 ```mooncram
 $ "$TOML_CLI" --version
-toml 0.2.3
+0.2.3
 ```
 
 ```mooncram
 $ "$TOML_CLI" --help
-toml 0.2.3
+Usage: toml [file] [command]
 
-Usage:
-  toml format <file>
-  toml check <file>
-  toml <file>
+Parse, validate, and format TOML files.
 
 Commands:
-  format <file>  Parse TOML and print normalized TOML.
-  check <file>   Validate TOML without printing parsed output.
+  format  Parse TOML and print normalized TOML.
+  check   Validate TOML without printing parsed output.
+  help    Print help for the subcommand(s).
+
+Arguments:
+  file  Parse TOML and print normalized TOML.
 
 Options:
-  -h, --help     Show this help.
-  --version      Show the CLI version.
+  -h, --help     Show help information.
+  -V, --version  Show version information.
+```
+
+```mooncram
+$ "$TOML_CLI"
+Usage: toml [file] [command]
+
+Parse, validate, and format TOML files.
+
+Commands:
+  format  Parse TOML and print normalized TOML.
+  check   Validate TOML without printing parsed output.
+  help    Print help for the subcommand(s).
+
+Arguments:
+  file  Parse TOML and print normalized TOML.
+
+Options:
+  -h, --help     Show help information.
+  -V, --version  Show version information.
 ```
 
 ## Format A File


### PR DESCRIPTION
## Summary

- replace the hand-written TOML CLI argument matching with a declarative `@argparse.Command`
- call the free `@argparse.parse(...)` entry point from `run`
- update Moon Cram snapshots for argparse-generated help/version output and add a no-argument help case

## Validation

- `moon fmt`
- `moon check --deny-warn`
- `moon test`
- `moon info`
- `moon build --target native --release`
- `TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram --no-color`