### PR TITLE
simplify moon cram cli checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
 
       - name: moon cram (native CLI)
         if: matrix.channel == 'nightly'
-        run: |
-          moon build --target native --release
-          TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
+        run: moon cram test --release tests/cram
 
       # - name: moon test
       #   run: moon test --enable-coverage

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -75,21 +75,20 @@ import {
 
 ## Command-Line Usage
 
-The module includes a native `toml` CLI in `cmd/main` for validating and
+The module includes a native `toml` CLI in `cmd/toml` for validating and
 normalizing TOML files:
 
 ```bash
-moon run --target native cmd/main -- --help
-moon run --target native cmd/main -- check config.toml
-moon run --target native cmd/main -- format config.toml
+moon run --target native cmd/toml -- --help
+moon run --target native cmd/toml -- check config.toml
+moon run --target native cmd/toml -- format config.toml
 ```
 
-For release-style CLI testing, build the native binary and run the Moon Cram
-transcript tests:
+For release-style CLI testing, run the Moon Cram transcript tests. `moon cram`
+builds the native CLI and puts `toml.exe` on `PATH`:
 
 ```bash
-moon build --target native --release
-TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
+moon cram test --release tests/cram
 ```
 
 ## Quick Start
@@ -562,7 +561,7 @@ toml-parser/
 - **Core Parser** (`toml.mbt`, `parser.mbt`) - Main TOML parsing implementation with full TOML 1.0 specification support, recursive descent parser with error recovery
 - **Tokenizer** (`internal/tokenize/`) - Lexical analysis and tokenization engine supporting all TOML tokens including special float values (inf, nan)
 - **Utilities** (`toml_utils.mbt`) - Helper functions for table creation, dotted key handling, and nested structure management
-- **Demo Application** (`cmd/main/`) - Interactive command-line examples demonstrating parser capabilities
+- **CLI Application** (`cmd/toml/`) - Command-line validation and formatting for TOML files
 - **Comprehensive Test Suite** (8000+ lines) - Extensive coverage including:
   - Unit tests for all data types and features
   - Official TOML specification compliance tests
@@ -683,10 +682,10 @@ moon test                              # unit tests (224 tests)
 moon test e2e -v --target native       # e2e toml-test suite (745 tests)
 ```
 
-### Running the Demo
+### Running the CLI
 
 ```bash
-moon run cmd/main
+moon run cmd/toml
 ```
 
 ### Building

--- a/cmd/toml/main.mbt
+++ b/cmd/toml/main.mbt
@@ -73,7 +73,7 @@ fn format_file(path : String) -> Int {
       return 1
     }
   }
-  let value = @toml.parse(source) catch {
+  let value = @toml_lib.parse(source) catch {
     err => {
       println("error: failed to parse \{path}: \{err}")
       return 1
@@ -91,7 +91,7 @@ fn check_file(path : String) -> Int {
       return 1
     }
   }
-  let _ = @toml.parse(source) catch {
+  let _ = @toml_lib.parse(source) catch {
     err => {
       println("error: failed to parse \{path}: \{err}")
       return 1

--- a/cmd/toml/moon.pkg
+++ b/cmd/toml/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "bobzhang/toml",
+  "bobzhang/toml" @toml_lib,
   "moonbitlang/core/argparse",
   "moonbitlang/core/env",
   "moonbitlang/x/fs",

--- a/cmd/toml/pkg.generated.mbti
+++ b/cmd/toml/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "bobzhang/toml/cmd/main"
+package "bobzhang/toml/cmd/toml"
 
 // Values
 

--- a/tests/cram/toml_cli.md
+++ b/tests/cram/toml_cli.md
@@ -1,22 +1,21 @@
 # TOML CLI Cram Tests
 
-These Moon Cram tests document the native `toml` executable. Set `TOML_CLI` to
-the native release binary before running them:
+These Moon Cram tests document the native `toml` executable. `moon cram` builds
+the native CLI and puts `toml.exe` on `PATH`:
 
 ```bash
-moon build --target native --release
-TOML_CLI="$PWD/_build/native/release/build/bobzhang/toml/cmd/main/main.exe" moon cram test tests/cram
+moon cram test --release tests/cram
 ```
 
 ## Help And Version
 
 ```mooncram
-$ "$TOML_CLI" --version
+$ toml.exe --version
 0.2.3
 ```
 
 ```mooncram
-$ "$TOML_CLI" --help
+$ toml.exe --help
 Usage: toml [file] [command]
 
 Parse, validate, and format TOML files.
@@ -35,7 +34,7 @@ Options:
 ```
 
 ```mooncram
-$ "$TOML_CLI"
+$ toml.exe
 Usage: toml [file] [command]
 
 Parse, validate, and format TOML files.
@@ -62,7 +61,7 @@ $ cat > sample.toml <<'EOF'
 > [server]
 > enabled = true
 > EOF
-> "$TOML_CLI" format sample.toml
+> toml.exe format sample.toml
 title = "MoonBit"
 
 ports = [8000, 8001]
@@ -79,7 +78,7 @@ $ cat > valid.toml <<'EOF'
 > package = "toml"
 > version = "0.2.3"
 > EOF
-> "$TOML_CLI" check valid.toml
+> toml.exe check valid.toml
 valid.toml: OK
 ```
 
@@ -89,7 +88,7 @@ valid.toml: OK
 $ cat > invalid.toml <<'EOF'
 > key =
 > EOF
-> "$TOML_CLI" check invalid.toml
+> toml.exe check invalid.toml
 error: failed to parse invalid.toml: Failure(parser.mbt:*@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 6 }, end: { line: 2, column: 1 } }) (glob)
 [1]
 ```


### PR DESCRIPTION
## Summary

- Rename the native CLI package from `cmd/main` to `cmd/toml` so `moon cram` exposes `toml.exe` on `PATH`.
- Run cram tests directly in CI with `moon cram test --release tests/cram`.
- Update README and cram transcripts to call `toml.exe` directly instead of setting `TOML_CLI` to a hard-coded build path.
- Alias the library import as `@toml_lib` inside the CLI package to avoid colliding with the renamed package alias.

## Validation

- `moon fmt`
- `moon info`
- `moon cram test --release tests/cram`
- `moon check --deny-warn`
- `moon test` (397 passed)
- `moon run --target native cmd/toml -- --version`
- `git diff --check`
