### PR TITLE
chore: replace deprecated try? with try/catch/noraise [warning 0020]

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -227,13 +227,21 @@ test {
   assert_eq(table.length(), 0) // Empty table from error handler
 
   // Error handling with try? - converts to Result type
-  let result = try? @toml.parse("key = \"value\"")
+  let result = try @toml.parse("key = \"value\"") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   guard result is Ok(TomlTable({ "key": _, .. })) else {
     fail("Should have parsed successfully with key")
   }
 
   // Parsing error example
-  let bad_result = try? @toml.parse("bad syntax here")
+  let bad_result = try @toml.parse("bad syntax here") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   assert_true(bad_result is Err(_))
 }
 ```

--- a/comprehensive_test.mbt
+++ b/comprehensive_test.mbt
@@ -652,7 +652,11 @@ test "inline table error locations" {
 
   // Test 5: Invalid syntax after comma
   debug_inspect(
-    try? @toml.parse("table = {key1 = \"val1\", }"),
+    try @toml.parse("table = {key1 = \"val1\", }") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "table": TomlTable({ "key1": TomlString("val1") }) }))
     ),
@@ -972,7 +976,11 @@ test "newline significate" {
     #|]  
     #|
   debug_inspect(
-    try? @toml.parse(data3),
+    try @toml.parse(data3) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "x": TomlArray([TomlInteger(1), TomlInteger(2)]) }))
     ),

--- a/coverage_improvement_test.mbt
+++ b/coverage_improvement_test.mbt
@@ -22,7 +22,11 @@ test "test complex TOML with all token types" {
     #|
   // This now successfully parses with nested tables support
   debug_inspect(
-    try? @toml.parse(complex_toml),
+    try @toml.parse(complex_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(
       #|  TomlTable(
@@ -93,9 +97,13 @@ test "test tokenizer unreachable path coverage" {
 test "test edge case number formats for error paths" {
   // Try to trigger integer parsing errors
 
-  let tokens = try? @tokenize.tokenize(
-    "huge = 999999999999999999999999999999999999999",
-  )
+  let tokens = try
+    @tokenize.tokenize("huge = 999999999999999999999999999999999999999")
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     tokens,
     content=(
@@ -141,7 +149,11 @@ test "test various escape sequences coverage" {
     #|quote = "say \"hello\""
     #|
   debug_inspect(
-    try? @toml.parse(toml_with_escapes),
+    try @toml.parse(toml_with_escapes) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(
       #|  TomlTable(
@@ -167,7 +179,11 @@ test "test whitespace and comment skipping" {
     #|key2 = "value2"
     #|
   debug_inspect(
-    try? @toml.parse(toml_with_whitespace),
+    try @toml.parse(toml_with_whitespace) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "key1": TomlString("value1"), "key2": TomlString("value2") }))
     ),

--- a/e2e/e2e_test.mbt
+++ b/e2e/e2e_test.mbt
@@ -20,7 +20,11 @@ async test "valid toml-test suite" {
         continue
       }
     }
-    let parsed = try? @toml.parse(toml_content)
+    let parsed = try @toml.parse(toml_content) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    }
     match parsed {
       Err(e) => {
         failures.push("[PARSE-ERROR] \{toml_path}: \{e}")

--- a/e2e/known_failures_test.mbt
+++ b/e2e/known_failures_test.mbt
@@ -7,7 +7,11 @@
 
 ///|
 test "fixed: [a-a-a] table header parses correctly" {
-  let result = try? @toml.parse("[a-a-a]\n_ = false\n")
+  let result = try @toml.parse("[a-a-a]\n_ = false\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -18,7 +22,11 @@ test "fixed: [a-a-a] table header parses correctly" {
 
 ///|
 test "fixed: leading underscore value rejected (not infinite loop)" {
-  let result = try? @toml.parse("x = _1.2\n")
+  let result = try @toml.parse("x = _1.2\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -33,7 +41,11 @@ test "fixed: leading underscore value rejected (not infinite loop)" {
 
 ///|
 test "fixed: positive prefix '+' tokenized for integers" {
-  let result = try? @toml.parse("pos = +99\n")
+  let result = try @toml.parse("pos = +99\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -44,7 +56,11 @@ test "fixed: positive prefix '+' tokenized for integers" {
 
 ///|
 test "fixed: positive prefix '+' tokenized for floats" {
-  let result = try? @toml.parse("pos = +1.0\n")
+  let result = try @toml.parse("pos = +1.0\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -59,7 +75,11 @@ test "fixed: positive prefix '+' tokenized for floats" {
 
 ///|
 test "fixed: CRLF line ending handled" {
-  let result = try? @toml.parse("key = \"val\"\r\n")
+  let result = try @toml.parse("key = \"val\"\r\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -74,7 +94,11 @@ test "fixed: CRLF line ending handled" {
 
 ///|
 test "fixed: datetime with space separator" {
-  let result = try? @toml.parse("dt = 1987-07-05 17:45:00Z\n")
+  let result = try @toml.parse("dt = 1987-07-05 17:45:00Z\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -89,7 +113,11 @@ test "fixed: datetime with space separator" {
 
 ///|
 test "fixed: numeric key leading zeros preserved" {
-  let result = try? @toml.parse("0123 = true\n")
+  let result = try @toml.parse("0123 = true\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -110,7 +138,11 @@ test "fixed: multiline string line ending backslash" {
     #|
     #|  fox jumps over the lazy dog."""
     #|
-  let result = try? @toml.parse(input)
+  let result = try @toml.parse(input) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -125,7 +157,11 @@ test "fixed: multiline string line ending backslash" {
 
 ///|
 test "fixed: hex escape \\xHH" {
-  let result = try? @toml.parse("esc = \"\\x41\"\n")
+  let result = try @toml.parse("esc = \"\\x41\"\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -136,7 +172,11 @@ test "fixed: hex escape \\xHH" {
 
 ///|
 test "fixed: escape \\e (ESC)" {
-  let result = try? @toml.parse("esc = \"\\e\"\n")
+  let result = try @toml.parse("esc = \"\\e\"\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -163,7 +203,11 @@ test "bug: array of tables cannot reopen" {
     #|[[fruits]]
     #|name = "banana"
     #|
-  let _ = try? @toml.parse(input)
+  let _ = try @toml.parse(input) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // Should parse without error
 }
 
@@ -173,7 +217,11 @@ test "bug: array of tables cannot reopen" {
 
 ///|
 test "fixed: keyword as table name" {
-  let result = try? @toml.parse("[true]\nx = 1\n")
+  let result = try @toml.parse("[true]\nx = 1\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -196,7 +244,11 @@ test "bug: inline table newlines (TOML 1.1)" {
     #|  b = 2
     #|}
     #|
-  let _ = try? @toml.parse(input)
+  let _ = try @toml.parse(input) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
 }
 
 // ============================================================
@@ -207,7 +259,11 @@ test "bug: inline table newlines (TOML 1.1)" {
 ///|
 #skip
 test "bug: datetime millisecond trailing zeros" {
-  let result = try? @toml.parse("dt = 1987-07-05T17:45:56.600Z\n")
+  let result = try @toml.parse("dt = 1987-07-05T17:45:56.600Z\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // Should preserve .600, not truncate to .6
   debug_inspect(result, content="")
 }
@@ -221,7 +277,11 @@ test "fixed: multiline string with consecutive quotes" {
   let input =
     #|str = """Here are two quotes: "". Cool."""
     #|
-  let result = try? @toml.parse(input)
+  let result = try @toml.parse(input) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -236,7 +296,11 @@ test "fixed: multiline string with consecutive quotes" {
 
 ///|
 test "fixed: dashed bare key starting with dash" {
-  let result = try? @toml.parse("-key = 1\n")
+  let result = try @toml.parse("-key = 1\n") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(

--- a/e2e/runner.mbt
+++ b/e2e/runner.mbt
@@ -46,7 +46,11 @@ pub fn run_single_valid_test(toml_path : String) -> String? raise @fs.IOError {
   let expected : Json = @json.parse(expected_json_str) catch {
     e => return Some("\{toml_path}: failed to parse expected JSON: \{e}")
   }
-  let parsed = try? @toml.parse(toml_content)
+  let parsed = try @toml.parse(toml_content) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   match parsed {
     Err(e) => Some("[PARSE-ERROR] \{toml_path}: \{e}")
     Ok(value) => {
@@ -72,7 +76,11 @@ pub fn run_single_invalid_test(toml_path : String) -> String? raise @fs.IOError 
     // Non-UTF-8 file: parser would reject this, count as pass
     _ => return None
   }
-  let parsed = try? @toml.parse(toml_content)
+  let parsed = try @toml.parse(toml_content) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   match parsed {
     Ok(_) => Some("[PASS-BUT-SHOULD-FAIL] \{toml_path}")
     Err(_) => None
@@ -208,8 +216,16 @@ fn float_values_equal(a : Map[String, Json], b : Map[String, Json]) -> Bool {
     return va_neg_zero == vb_neg_zero
   }
   // Parse and compare numerically
-  let fa = try? @string.parse_double(va)
-  let fb = try? @string.parse_double(vb)
+  let fa = try @string.parse_double(va) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
+  let fb = try @string.parse_double(vb) catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   match (fa, fb) {
     (Ok(a), Ok(b)) => a == b
     _ => false

--- a/internal/tokenize/lexer_bug_test.mbt
+++ b/internal/tokenize/lexer_bug_test.mbt
@@ -1,10 +1,16 @@
 ///|
 test "test invalid float parsing" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|invalid = 1.2.3
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|invalid = 1.2.3
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     maybe_tokens,
     content=(
@@ -34,11 +40,17 @@ test "test invalid float parsing" {
 
 ///|
 test "test invalid hex digit error" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|hex = 0xGHI
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|hex = 0xGHI
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -49,11 +61,17 @@ test "test invalid hex digit error" {
 
 ///|
 test "test octal without digits" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|test = 0o
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|test = 0o
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -64,11 +82,17 @@ test "test octal without digits" {
 
 ///|
 test "test binary without digits" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|test = 0b
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|test = 0b
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -79,11 +103,17 @@ test "test binary without digits" {
 
 ///|
 test "test hex with invalid delimiter" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|hex = 0x123XYZ
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|hex = 0x123XYZ
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -94,11 +124,17 @@ test "test hex with invalid delimiter" {
 
 ///|
 test "test hex regex is anchored to current view" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|hex = 0xG0x10
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|hex = 0xG0x10
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -139,11 +175,17 @@ test "test datetime timezone regex is anchored to current view" {
 
 ///|
 test "test octal regex is anchored to current view" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|oct = 0o80o7
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|oct = 0o80o7
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -154,11 +196,17 @@ test "test octal regex is anchored to current view" {
 
 ///|
 test "test binary regex is anchored to current view" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|bin = 0b20b10
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|bin = 0b20b10
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -250,11 +298,17 @@ test "test hex case variations" {
 
 ///|
 test "test octal with invalid digits" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|oct = 0o789
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|oct = 0o789
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -320,11 +374,17 @@ test "test octal with valid delimiters" {
 
 ///|
 test "test binary with invalid digits" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|bin = 0b1012
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|bin = 0b1012
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(

--- a/internal/tokenize/lexer_test.mbt
+++ b/internal/tokenize/lexer_test.mbt
@@ -587,11 +587,17 @@ test "test escaped single quote in string" {
 
 ///|
 test "test invalid escape sequence error" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "test\z invalid"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "test\z invalid"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // TODO: ArgsLoc no absolute loc
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
@@ -603,11 +609,17 @@ test "test invalid escape sequence error" {
 
 ///|
 test "test unterminated string error" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "unterminated
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "unterminated
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // TODO: ArgsLoc no absolute loc
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
@@ -619,11 +631,17 @@ test "test unterminated string error" {
 
 ///|
 test "test unexpected end after escape" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "test\
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "test\
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // TODO: ArgsLoc no absolute loc
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
@@ -635,11 +653,17 @@ test "test unexpected end after escape" {
 
 ///|
 test "test invalid characters" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key @ value
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key @ value
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -708,7 +732,11 @@ test "lexer expect_string failure" {
       #|hello world
     ),
   )
-  let maybe_result = try? lexer.expect_string("goodbye")
+  let maybe_result = try lexer.expect_string("goodbye") catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_result.unwrap_err()),
     content=(
@@ -776,11 +804,17 @@ test "unicode 4 escape uppercase hex" {
 ///|
 /// Test Unicode 4-digit escape invalid hex digit
 test "unicode 4 escape invalid hex" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\uGHIJ"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\uGHIJ"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -792,11 +826,17 @@ test "unicode 4 escape invalid hex" {
 ///|
 /// Test Unicode 4-digit escape incomplete sequence
 test "unicode 4 escape incomplete" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\u123"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\u123"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -808,11 +848,17 @@ test "unicode 4 escape incomplete" {
 ///|
 /// Test Unicode 4-digit escape invalid code point
 test "unicode 4 escape invalid code point" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\uD800"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\uD800"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -880,11 +926,17 @@ test "unicode 8 escape uppercase hex" {
 ///|
 /// Test Unicode 8-digit escape invalid hex digit
 test "unicode 8 escape invalid hex" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U0000000G"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U0000000G"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -896,11 +948,17 @@ test "unicode 8 escape invalid hex" {
 ///|
 /// Test Unicode 8-digit escape incomplete sequence
 test "unicode 8 escape incomplete" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U0000001"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U0000001"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -912,11 +970,17 @@ test "unicode 8 escape incomplete" {
 ///|
 /// Test Unicode 8-digit escape invalid code point (too large)
 test "unicode 8 escape invalid code point large" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U00110000"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U00110000"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -928,11 +992,17 @@ test "unicode 8 escape invalid code point large" {
 ///|
 /// Test Unicode 8-digit escape invalid code point (surrogate range)
 test "unicode 8 escape invalid code point surrogate" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U0000D800"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U0000D800"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -944,11 +1014,17 @@ test "unicode 8 escape invalid code point surrogate" {
 ///|
 /// Test Unicode 8-digit escape invalid code point conversion
 test "unicode 8 escape invalid conversion" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U7FFFFFFF"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U7FFFFFFF"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1097,11 +1173,17 @@ test "multiline basic string line ending backslash CR" {
 ///|
 /// Test multiline basic string invalid escape
 test "multiline basic string invalid escape" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """\z"""
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """\z"""
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1113,11 +1195,17 @@ test "multiline basic string invalid escape" {
 ///|
 /// Test multiline basic string unexpected end after escape
 test "multiline basic string unexpected end after escape" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """\
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """\
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1129,11 +1217,17 @@ test "multiline basic string unexpected end after escape" {
 ///|
 /// Test multiline basic string unterminated
 test "multiline basic string unterminated" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """incomplete
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """incomplete
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1145,11 +1239,17 @@ test "multiline basic string unterminated" {
 ///|
 /// Test multiline basic string early termination in loop
 test "multiline basic string early termination" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """line
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """line
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1185,11 +1285,17 @@ test "multiline literal string CRLF" {
 ///|
 /// Test multiline literal string unterminated
 test "multiline literal string unterminated" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = '''incomplete
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = '''incomplete
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1202,11 +1308,17 @@ test "multiline literal string unterminated" {
 /// Test hex number with no digits after 0x
 test "hex number invalid digit error path" {
   // This should fail because there are no hex digits after 0x
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0x
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0x
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1361,11 +1473,17 @@ test "multiline basic string CR only" {
 /// Test multiline basic string early termination at None peek
 test "multiline basic string none peek" {
   // This creates a string that will reach None in the peek() during processing
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """incomplete string
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """incomplete string
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1516,11 +1634,17 @@ test "test hex overflow edge case" {
 test "unicode code point conversion failure" {
   // Try to find a Unicode code that's valid as int but invalid as char
   // Code point 0x110000 is too large for valid Unicode
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U00110000"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U00110000"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   let error_msg = maybe_tokens.unwrap_err().to_string()
   match error_msg.strip_prefix("Invalid Unicode code point: ") {
     Some(_) => debug_inspect(true, content="true") // Expected error
@@ -1532,11 +1656,17 @@ test "unicode code point conversion failure" {
 /// Test very specific multiline string that could reach None peek
 test "multiline string abrupt end" {
   // Create a multiline string that ends abruptly without proper closing
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """content without closing
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """content without closing
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   let error_msg = maybe_tokens.unwrap_err().to_string()
   // This should trigger one of the unterminated multiline string errors
   let is_unterminated = match
@@ -1552,11 +1682,17 @@ test "multiline string abrupt end" {
 test "unicode 8 digit none conversion attempt" {
   // Try an edge case that might trigger the None path in unicode 8 escape
   // Use a very large value that might fail conversion
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = "\U7FFFFFFF"
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = "\U7FFFFFFF"
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   let error_msg = maybe_tokens.unwrap_err().to_string()
   // Should get invalid Unicode code point error
   let has_invalid_unicode = match
@@ -1600,11 +1736,17 @@ test "attempt hex digit error path" {
 /// Test multiline string with potential truncation
 test "multiline string potential truncation" {
   // Try to create a scenario where multiline string processing might hit None
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = """partial
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = """partial
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // Should get unterminated string error
   let error_msg = maybe_tokens.unwrap_err().to_string()
   let is_unterminated = error_msg.contains("Unterminated")
@@ -1613,11 +1755,17 @@ test "multiline string potential truncation" {
 
 ///|
 test "trailing _ in binary number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0b10_10_
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0b10_10_
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1628,11 +1776,17 @@ test "trailing _ in binary number" {
 
 ///|
 test "consequence _ in binary number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0b10__10_10
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0b10__10_10
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // according to spec, this should fail
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
@@ -1644,11 +1798,17 @@ test "consequence _ in binary number" {
 
 ///|
 test "trailing _ in hex number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0xAB_CD_
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0xAB_CD_
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1659,11 +1819,17 @@ test "trailing _ in hex number" {
 
 ///|
 test "consecutive _ in hex number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0xAB__CD_EF
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0xAB__CD_EF
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // according to spec, this should fail
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
@@ -1675,11 +1841,17 @@ test "consecutive _ in hex number" {
 
 ///|
 test "trailing _ in octal number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0o755_
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0o755_
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),
     content=(
@@ -1690,11 +1862,17 @@ test "trailing _ in octal number" {
 
 ///|
 test "consecutive _ in octal number" {
-  let maybe_tokens = try? @tokenize.tokenize(
-    (
-      #|key = 0o7__55_44
-    ),
-  )
+  let maybe_tokens = try
+    @tokenize.tokenize(
+      (
+        #|key = 0o7__55_44
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   // according to spec, this should fail
   debug_inspect(
     unwrap_failure_message(maybe_tokens.unwrap_err()),

--- a/parser_test.mbt
+++ b/parser_test.mbt
@@ -98,11 +98,17 @@ test "parse array" {
 
 ///|
 test "parse array ending with exponent float" {
-  let result = try? @toml.parse(
-    (
-      #|numbers = [-1e2]
-    ),
-  )
+  let result = try
+    @toml.parse(
+      (
+        #|numbers = [-1e2]
+      ),
+    )
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -139,7 +145,11 @@ test "test parser expect method failure" {
 ///|
 test "test parser EOF handling in peek" {
   debug_inspect(
-    try? @toml.parse(""),
+    try @toml.parse("") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({}))
     ),
@@ -169,7 +179,11 @@ test "test parser rejects dash-starting identifier as value" {
 ///|
 test "test inline table with string keys" {
   debug_inspect(
-    try? @toml.parse("table = {\"string key\" = \"value\"}"),
+    try @toml.parse("table = {\"string key\" = \"value\"}") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "table": TomlTable({ "string key": TomlString("value") }) }))
     ),
@@ -203,7 +217,11 @@ test "test table header with string name" {
     #|key = "value"
     #|
   debug_inspect(
-    try? @toml.parse(string_table_name_toml),
+    try @toml.parse(string_table_name_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "table name": TomlTable({ "key": TomlString("value") }) }))
     ),
@@ -217,7 +235,11 @@ test "test table header numeric name" {
     #|key = "value"
     #|
   debug_inspect(
-    try? @toml.parse(numeric_table_name_toml),
+    try @toml.parse(numeric_table_name_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "123": TomlTable({ "key": TomlString("value") }) }))
     ),
@@ -311,7 +333,11 @@ test "test exponent-like bare keys" {
     #|-10e-1 = "d"
     #|
   debug_inspect(
-    try? @toml.parse(exponent_like_keys_toml),
+    try @toml.parse(exponent_like_keys_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(
       #|  TomlTable(
@@ -340,7 +366,11 @@ test "test exponent-like bare table headers" {
     #|value = "d"
     #|
   debug_inspect(
-    try? @toml.parse(exponent_like_table_names_toml),
+    try @toml.parse(exponent_like_table_names_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(
       #|  TomlTable(
@@ -378,7 +408,11 @@ test "overflow float rejected in value position" {
 test "overflow float accepted as bare key" {
   // The same overflow token is valid as a bare key (all chars are A-Za-z0-9_-)
   debug_inspect(
-    try? @toml.parse("-31e368 = \"ok\"\n"),
+    try @toml.parse("-31e368 = \"ok\"\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "-31e368": TomlString("ok") }))
     ),
@@ -389,19 +423,31 @@ test "overflow float accepted as bare key" {
 test "special float keywords as keys" {
   // inf, nan, +inf, -inf, etc. are valid bare keys in TOML
   debug_inspect(
-    try? @toml.parse("+inf = 1\n"),
+    try @toml.parse("+inf = 1\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "+inf": TomlInteger(1) }))
     ),
   )
   debug_inspect(
-    try? @toml.parse("-inf = 2\n"),
+    try @toml.parse("-inf = 2\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "-inf": TomlInteger(2) }))
     ),
   )
   debug_inspect(
-    try? @toml.parse("nan = 3\n"),
+    try @toml.parse("nan = 3\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "nan": TomlInteger(3) }))
     ),
@@ -412,14 +458,22 @@ test "special float keywords as keys" {
 test "dotted key with float-like segments" {
   // Float token with dot in raw string should split into dotted keys
   debug_inspect(
-    try? @toml.parse("1.2 = \"a\"\n"),
+    try @toml.parse("1.2 = \"a\"\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "1": TomlTable({ "2": TomlString("a") }) }))
     ),
   )
   // Float-like key followed by dotted sub-key
   debug_inspect(
-    try? @toml.parse("[-80e-2.sub]\nval = 1\n"),
+    try @toml.parse("[-80e-2.sub]\nval = 1\n") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "-80e-2": TomlTable({ "sub": TomlTable({ "val": TomlInteger(1) }) }) }))
     ),
@@ -461,7 +515,11 @@ test "test table name conflicts with existing value" {
 /// Tests for inline table edge cases  
 test "test empty inline table" {
   debug_inspect(
-    try? @toml.parse("empty = {}"),
+    try @toml.parse("empty = {}") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "empty": TomlTable({}) }))
     ),
@@ -471,7 +529,11 @@ test "test empty inline table" {
 ///|
 test "test nested inline tables" {
   debug_inspect(
-    try? @toml.parse("table = {inner = {key = \"value\"}}"),
+    try @toml.parse("table = {inner = {key = \"value\"}}") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "table": TomlTable({ "inner": TomlTable({ "key": TomlString("value") }) }) }))
     ),
@@ -481,7 +543,11 @@ test "test nested inline tables" {
 ///|
 test "test inline table with multiple key types" {
   debug_inspect(
-    try? @toml.parse("mixed = {\"quoted\" = 1, unquoted = 2}"),
+    try @toml.parse("mixed = {\"quoted\" = 1, unquoted = 2}") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(TomlTable({ "mixed": TomlTable({ "quoted": TomlInteger(1), "unquoted": TomlInteger(2) }) }))
     ),
@@ -491,7 +557,11 @@ test "test inline table with multiple key types" {
 ///|
 test "test inline table with array values" {
   debug_inspect(
-    try? @toml.parse("table = {arr = [1, 2, 3], str = \"test\"}"),
+    try @toml.parse("table = {arr = [1, 2, 3], str = \"test\"}") catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
       #|Ok(
       #|  TomlTable(
@@ -656,5 +726,12 @@ test "complex dotted keys" {
     #|server."port number".8080.config = 3
     #|
   // TODO: fix
-  debug_inspect(try? @toml.parse(data), content="")
+  debug_inspect(
+    try @toml.parse(data) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
+    content="",
+  )
 }

--- a/parser_wbtest.mbt
+++ b/parser_wbtest.mbt
@@ -176,7 +176,12 @@ test "parse_dotted_key - error cases" {
   // Test error when no key is found
   let tokens = @tokenize.tokenize("=")
   let parser = Parser::new(tokens)
-  guard (try? parser.parse_dotted_key()) is Err(err) else {
+  guard (try parser.parse_dotted_key() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(err) else {
     fail("Expected error but got success")
   }
   debug_inspect(
@@ -196,7 +201,12 @@ test "parse_dotted_key - error after dot" {
   // Test error when dot is followed by invalid token
   let tokens = @tokenize.tokenize("key.=")
   let parser = Parser::new(tokens)
-  guard (try? parser.parse_dotted_key()) is Err(result) else {
+  guard (try parser.parse_dotted_key() catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    })
+    is Err(result) else {
     fail("Expected error but got success")
   }
   debug_inspect(

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -296,7 +296,13 @@ test "create_array_of_tables - path conflicts with non-table" {
 
   // Try to create array of tables at ["products", "items"]
   // This should fail because "products" is not a table
-  let result = try? create_array_of_tables(root_table, ["products", "items"])
+  let result = try
+    create_array_of_tables(root_table, ["products", "items"])
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -319,7 +325,13 @@ test "create_array_of_tables - final key conflicts with non-array" {
   )
 
   // Try to treat servers.alpha as array of tables
-  let result = try? create_array_of_tables(root_table, ["servers", "alpha"])
+  let result = try
+    create_array_of_tables(root_table, ["servers", "alpha"])
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(
     result,
     content=(
@@ -548,11 +560,13 @@ test "set dotted key value - reject duplicate key" {
   let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["config", "timeout"], TomlInteger(30))
   // Duplicate key should be rejected
-  let result = try? set_dotted_key_value(
-    table,
-    ["config", "timeout"],
-    TomlInteger(60),
-  )
+  let result = try
+    set_dotted_key_value(table, ["config", "timeout"], TomlInteger(60))
+  catch {
+    err => Err(err)
+  } noraise {
+    value => Ok(value)
+  }
   debug_inspect(result, content="Err(DuplicateKey(\"timeout\"))")
 }
 


### PR DESCRIPTION
## Summary
- Mechanical rewrite of `try? expr` → `try expr catch { err => Err(err) } noraise { value => Ok(value) }` across 11 files (92 occurrences).
- Silences all instances of MoonBit warning `[0020]` without changing `Result`-based semantics — every call site still pattern-matches on `Ok(_)` / `Err(_)`.
- Leaves the untracked `quickcheck/` tree alone.

## Test plan
- [x] `moon fmt`
- [x] `moon check` — 0 warnings, 0 errors
- [x] `moon test` — 397/397 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)