### PR TITLE
refactor: rename Lexer::new -> Lexer::Lexer and Parser::new -> Parser::Parser

### DIFF
--- a/internal/tokenize/lexer_test.mbt
+++ b/internal/tokenize/lexer_test.mbt
@@ -727,7 +727,7 @@ test "test dash-starting identifier tokenized before parser validation" {
 ///|
 /// Test lexer expect_string error cases
 test "lexer expect_string failure" {
-  let lexer = @lexer.Lexer::new(
+  let lexer = @lexer.Lexer::Lexer(
     (
       #|hello world
     ),

--- a/internal/tokenize/test_utils_test.mbt
+++ b/internal/tokenize/test_utils_test.mbt
@@ -45,7 +45,7 @@ test "verify lexer_expect_to_fail output" {
 
 ///|
 test "verify lexer_action_expect_to_fail output" {
-  let lexer = @lexer.Lexer::new(
+  let lexer = @lexer.Lexer::Lexer(
     (
       #|hello world
     ),

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -595,7 +595,7 @@ fn @lexer.Lexer::read_octal_number(self : @lexer.Lexer) -> Int64 raise {
 
 ///|
 test {
-  let lexer = @lexer.Lexer::new(
+  let lexer = @lexer.Lexer::Lexer(
     (
       #|0o755
     ),
@@ -1129,7 +1129,7 @@ fn @lexer.Lexer::read_number(
 
 ///|
 test "read_number" {
-  let lexer = @lexer.Lexer::new("123")
+  let lexer = @lexer.Lexer::Lexer("123")
   debug_inspect(
     lexer.read_number(false),
     content=(
@@ -1345,7 +1345,7 @@ fn @lexer.Lexer::next_token(self : @lexer.Lexer) -> Token raise {
 ///|
 /// Tokenize entire input
 pub fn tokenize(input : String) -> Array[Token] raise {
-  let lexer = @lexer.Lexer::new(input)
+  let lexer = @lexer.Lexer::Lexer(input)
   let tokens = Array::new()
   for current_token = lexer.next_token() {
     match current_token {
@@ -1364,7 +1364,7 @@ pub fn tokenize(input : String) -> Array[Token] raise {
 ///|
 /// Test read_number
 test "read_number 2" {
-  let lexer = @lexer.Lexer::new("123")
+  let lexer = @lexer.Lexer::Lexer("123")
   debug_inspect(
     lexer.read_number(false),
     content=(
@@ -1379,7 +1379,7 @@ test "read_number 2" {
 ///|
 /// Test Unicode escape sequences
 test "unicode escape sequences" {
-  let lexer1 = @lexer.Lexer::new("\"\\u0041\"") // 'A'
+  let lexer1 = @lexer.Lexer::Lexer("\"\\u0041\"") // 'A'
   let result1 = lexer1.read_basic_string()
   debug_inspect(
     result1,
@@ -1387,7 +1387,7 @@ test "unicode escape sequences" {
       #|"A"
     ),
   )
-  let lexer2 = @lexer.Lexer::new("\"\\U00000041\"") // 'A'
+  let lexer2 = @lexer.Lexer::Lexer("\"\\U00000041\"") // 'A'
   let result2 = lexer2.read_basic_string()
   debug_inspect(
     result2,
@@ -1400,7 +1400,7 @@ test "unicode escape sequences" {
 ///|
 /// Test multiline basic string
 test "multiline basic string" {
-  let lexer = @lexer.Lexer::new("\"\"\"line1\nline2\"\"\"")
+  let lexer = @lexer.Lexer::Lexer("\"\"\"line1\nline2\"\"\"")
   lexer.expect_string("\"\"\"")
   let result = lexer.read_multiline_basic_string()
   debug_inspect(
@@ -1414,7 +1414,7 @@ test "multiline basic string" {
 ///|
 /// Test multiline literal string
 test "multiline literal string" {
-  let lexer = @lexer.Lexer::new("'''line1\nline2'''")
+  let lexer = @lexer.Lexer::Lexer("'''line1\nline2'''")
   lexer.expect_string("'''")
   let result = lexer.read_multiline_literal_string()
   debug_inspect(
@@ -1428,7 +1428,7 @@ test "multiline literal string" {
 ///|
 /// Test line ending backslash in multiline string
 test "line ending backslash" {
-  let lexer = @lexer.Lexer::new("\"\"\"line1\\\n   line2\"\"\"")
+  let lexer = @lexer.Lexer::Lexer("\"\"\"line1\\\n   line2\"\"\"")
   lexer.expect_string("\"\"\"")
   let result = lexer.read_multiline_basic_string()
   debug_inspect(
@@ -1442,7 +1442,7 @@ test "line ending backslash" {
 ///|
 /// Test basic string parsing
 test "basic string parsing" {
-  let lexer = @lexer.Lexer::new("\"Hello, \\\"world\\\"!\"")
+  let lexer = @lexer.Lexer::Lexer("\"Hello, \\\"world\\\"!\"")
   let result = lexer.read_basic_string()
   debug_inspect(
     result,
@@ -1455,7 +1455,7 @@ test "basic string parsing" {
 ///|
 /// Test literal string parsing  
 test "literal string parsing" {
-  let lexer = @lexer.Lexer::new("'Hello, world!'")
+  let lexer = @lexer.Lexer::Lexer("'Hello, world!'")
   let result = lexer.read_literal_string()
   debug_inspect(
     result,
@@ -1468,7 +1468,7 @@ test "literal string parsing" {
 ///|
 /// Test identifier parsing
 test "identifier parsing" {
-  let lexer = @lexer.Lexer::new("hello-world_123")
+  let lexer = @lexer.Lexer::Lexer("hello-world_123")
   let result = lexer.read_identifier()
   debug_inspect(
     result,
@@ -1481,7 +1481,7 @@ test "identifier parsing" {
 ///|
 /// Test hex number parsing
 test "hex number parsing" {
-  let lexer = @lexer.Lexer::new("0xDEADBEEF")
+  let lexer = @lexer.Lexer::Lexer("0xDEADBEEF")
   let result = lexer.read_hex_number()
   debug_inspect(result, content="3735928559")
 }
@@ -1489,7 +1489,7 @@ test "hex number parsing" {
 ///|
 /// Test octal number parsing  
 test "octal number parsing" {
-  let lexer = @lexer.Lexer::new("0o755")
+  let lexer = @lexer.Lexer::Lexer("0o755")
   let result = lexer.read_octal_number()
   debug_inspect(result, content="493")
 }
@@ -1497,7 +1497,7 @@ test "octal number parsing" {
 ///|
 /// Test binary number parsing
 test "binary number parsing" {
-  let lexer = @lexer.Lexer::new("0b1010")
+  let lexer = @lexer.Lexer::Lexer("0b1010")
   let result = lexer.read_binary_number()
   debug_inspect(result, content="10")
 }

--- a/lexer/README.mbt.md
+++ b/lexer/README.mbt.md
@@ -46,7 +46,7 @@ The main lexer struct maintains state and position:
 ```moonbit check
 ///|
 test "quick start example" {
-  let lexer = @lexer.Lexer::new("key = value")
+  let lexer = @lexer.Lexer::Lexer("key = value")
 
   // Peek at current character without advancing
   match lexer.peek() {
@@ -81,7 +81,7 @@ test "quick start example" {
 ```moonbit check
 ///|
 test "creating a lexer" {
-  let lexer = @lexer.Lexer::new("key = value")
+  let lexer = @lexer.Lexer::Lexer("key = value")
   inspect(lexer.get_position(), content="0")
   inspect(lexer.get_loc().line, content="1")
   inspect(lexer.get_loc().column, content="1")
@@ -93,7 +93,7 @@ test "creating a lexer" {
 ```moonbit check
 ///|
 test "position tracking example" {
-  let lexer = @lexer.Lexer::new("hello\nworld")
+  let lexer = @lexer.Lexer::Lexer("hello\nworld")
   inspect(lexer.get_loc().line, content="1")
   inspect(lexer.get_loc().column, content="1")
 
@@ -114,7 +114,7 @@ test "position tracking example" {
 ### Methods
 
 #### Creation
-- `Lexer::new(input : String) -> Lexer` - Create a new lexer with the given input
+- `Lexer::Lexer(input : String) -> Lexer` - Create a new lexer with the given input
 
 #### Character Operations
 - `peek() -> Char?` - Get current character without advancing
@@ -143,7 +143,7 @@ test "position tracking example" {
 ```moonbit check
 ///|
 test "core methods example" {
-  let lexer = @lexer.Lexer::new("hello\nworld")
+  let lexer = @lexer.Lexer::Lexer("hello\nworld")
   inspect(lexer.get_loc().line, content="1")
   inspect(lexer.get_loc().column, content="1")
 
@@ -166,7 +166,7 @@ test "core methods example" {
 ```moonbit check
 ///|
 test "character access example" {
-  let lexer = @lexer.Lexer::new("Hello")
+  let lexer = @lexer.Lexer::Lexer("Hello")
   debug_inspect(lexer.peek(), content="Some('H')")
   lexer.advance()
   debug_inspect(lexer.peek(), content="Some('e')")
@@ -180,7 +180,7 @@ The lexer integrates with MoonBit's string views for efficient processing:
 ```moonbit check
 ///|
 test "string views example" {
-  let lexer = @lexer.Lexer::new("😈x中world!")
+  let lexer = @lexer.Lexer::Lexer("😈x中world!")
   match lexer.view() {
     [.. "😈x", .. rest] => lexer.update_view(rest)
     _ => ()
@@ -194,7 +194,7 @@ test "string views example" {
 ```moonbit check
 ///|
 test "whitespace handling example" {
-  let lexer = @lexer.Lexer::new("  \t\rHello, world!")
+  let lexer = @lexer.Lexer::Lexer("  \t\rHello, world!")
   lexer.skip_whitespace()
   debug_inspect(lexer.peek(), content="Some('H')")
 }
@@ -207,7 +207,7 @@ The lexer provides methods to expect specific characters or strings:
 ```moonbit check
 ///|
 test "expectations example" {
-  let lexer = @lexer.Lexer::new("=true")
+  let lexer = @lexer.Lexer::Lexer("=true")
   // Expect a specific character
   lexer.expect_char('=', msg="Expected equals sign")
 
@@ -229,7 +229,7 @@ The lexer properly handles Unicode characters including surrogate pairs:
 ```moonbit check
 ///|
 test "unicode support example" {
-  let lexer = @lexer.Lexer::new("😈x")
+  let lexer = @lexer.Lexer::Lexer("😈x")
   inspect(lexer.get_position(), content="0")
   lexer.advance() // Correctly advances past the 2-byte emoji
   inspect(lexer.get_position(), content="2") // 2 bytes for emoji
@@ -244,7 +244,7 @@ Get current position information:
 ```moonbit check
 ///|
 test "position management example" {
-  let lexer = @lexer.Lexer::new("test")
+  let lexer = @lexer.Lexer::Lexer("test")
   let pos = lexer.get_loc() // Get Position struct
   let offset = lexer.get_position() // Get byte offset
   inspect(pos.line, content="1")
@@ -258,7 +258,7 @@ test "position management example" {
 ```moonbit check
 ///|
 test "position aware error handling example" {
-  let lexer = @lexer.Lexer::new("abc")
+  let lexer = @lexer.Lexer::Lexer("abc")
   lexer.advance() // move to 'b'
   lexer.advance() // move to 'c'
   let start_pos = lexer.get_loc()
@@ -272,7 +272,7 @@ test "position aware error handling example" {
 ```moonbit check
 ///|
 test "custom lexer implementation example" {
-  let lexer = @lexer.Lexer::new("a=b")
+  let lexer = @lexer.Lexer::Lexer("a=b")
   let tokens = []
 
   // Simple tokenization - process each character
@@ -304,7 +304,7 @@ test "custom lexer implementation example" {
 ```moonbit check
 ///|
 test "basic parsing example" {
-  let lexer = @lexer.Lexer::new("key = \"value\"")
+  let lexer = @lexer.Lexer::Lexer("key = \"value\"")
 
   // Skip initial whitespace
   lexer.skip_whitespace()

--- a/lexer/lexer.mbt
+++ b/lexer/lexer.mbt
@@ -19,7 +19,7 @@ struct Lexer {
 /// Get a view of the input string
 /// # Example:
 /// ```
-/// let lexer = Lexer::new("Hello, world!")
+/// let lexer = Lexer::Lexer("Hello, world!")
 /// lexer.advance()
 /// lexer.advance()
 /// inspect(lexer.view(), content="llo, world!")
@@ -32,7 +32,7 @@ pub fn Lexer::view(self : Lexer) -> StringView {
 /// Update the lexer's position and column based on a new view
 /// # Example:
 /// ```
-/// let lexer = Lexer::new("😈x中world!")
+/// let lexer = Lexer::Lexer("😈x中world!")
 /// match lexer.view() {
 ///  [.."😈x", .. rest] => lexer.update_view(rest)
 ///  _ => ()
@@ -47,14 +47,14 @@ pub fn Lexer::update_view(self : Lexer, view : StringView) -> Unit {
 
 ///|
 /// Create a new lexer
-pub fn Lexer::new(input : String) -> Lexer {
+pub fn Lexer::Lexer(input : String) -> Lexer {
   { input, position: 0, line: 1, column: 1 }
 }
 
 ///|
 /// Tests for lexer creation
 test "lexer creation" {
-  let lexer = Lexer::new("key = value")
+  let lexer = Lexer::Lexer("key = value")
   inspect(lexer.input, content="key = value")
   inspect(lexer.position, content="0")
   inspect(lexer.line, content="1")
@@ -66,7 +66,7 @@ test "lexer creation" {
 /// Note: This method does not skip '\n' characters as those are significant in TOML
 /// # Example:
 /// ```
-/// let lexer = Lexer::new("  \t\rHello, world!")
+/// let lexer = Lexer::Lexer("  \t\rHello, world!")
 /// lexer.skip_whitespace()
 /// inspect(lexer.peek(), content="Some('H')")
 /// ```
@@ -102,7 +102,7 @@ pub fn Lexer::skip_single_newline(self : Lexer) -> Unit {
 /// Get current character without advancing
 /// # Example:
 /// ```
-/// let lexer = Lexer::new("Hello, world!")
+/// let lexer = Lexer::Lexer("Hello, world!")
 /// inspect(lexer.peek(), content="Some('H')")
 /// lexer.advance()
 /// inspect(lexer.peek(), content="Some('e')")
@@ -222,7 +222,7 @@ pub fn Lexer::advance(self : Lexer) -> Unit {
 ///|
 /// Test position tracking with explicit new_line() API
 test "position tracking" {
-  let lexer = Lexer::new("hello\nworld")
+  let lexer = Lexer::Lexer("hello\nworld")
   inspect(lexer.get_loc().line, content="1")
   inspect(lexer.get_loc().column, content="1")
   lexer.advance() // h
@@ -244,7 +244,7 @@ test "position tracking" {
 ///|
 /// Test skip whitespace with position tracking
 test "skip whitespace with position tracking" {
-  let lexer = Lexer::new("  \t\rH")
+  let lexer = Lexer::Lexer("  \t\rH")
   lexer.skip_whitespace()
   inspect(lexer.get_loc().column, content="5") // moved past 4 whitespace chars
   debug_inspect(lexer.peek(), content="Some('H')")
@@ -253,7 +253,7 @@ test "skip whitespace with position tracking" {
 ///|
 /// Test explicit new_line API
 test "explicit new_line API" {
-  let lexer = Lexer::new("test")
+  let lexer = Lexer::Lexer("test")
   inspect(lexer.get_loc().line, content="1")
   inspect(lexer.get_loc().column, content="1")
   lexer.new_line()

--- a/lexer/pkg.generated.mbti
+++ b/lexer/pkg.generated.mbti
@@ -10,14 +10,16 @@ import {
 // Errors
 
 // Types and methods
-type Lexer
+pub struct Lexer {
+  // private fields
+}
+pub fn Lexer::Lexer(String) -> Self
 pub fn Lexer::advance(Self) -> Unit
 pub fn Lexer::error(Self, String) -> String
 pub fn Lexer::expect_char(Self, Char, msg? : String) -> Unit raise
 pub fn Lexer::expect_string(Self, String, msg? : String) -> Unit raise
 pub fn Lexer::get_loc(Self) -> Position
 pub fn Lexer::get_position(Self) -> Int
-pub fn Lexer::new(String) -> Self
 pub fn Lexer::new_line(Self) -> Unit
 pub fn Lexer::peek(Self) -> Char?
 pub fn Lexer::peek_charcode(Self) -> UInt16?

--- a/parser.mbt
+++ b/parser.mbt
@@ -299,7 +299,7 @@ let header_defined_marker : String = "\u0000__header__"
 /// `Result[TomlValue, Error]` instead.
 pub fn parse(input : String) -> TomlValue raise {
   let tokens = @tokenize.tokenize(input)
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let main_table = {}
   for current_table = main_table {
     parser.skip_newlines()

--- a/parser_wbtest.mbt
+++ b/parser_wbtest.mbt
@@ -5,7 +5,7 @@
 test "parse_dotted_key - simple identifier" {
   // Test parsing a simple identifier key
   let tokens = @tokenize.tokenize("simple")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -19,7 +19,7 @@ test "parse_dotted_key - simple identifier" {
 test "parse_dotted_key - dotted identifiers" {
   // Test parsing dotted identifier keys
   let tokens = @tokenize.tokenize("server.host.name")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -33,7 +33,7 @@ test "parse_dotted_key - dotted identifiers" {
 test "parse_dotted_key - string keys" {
   // Test parsing quoted string keys
   let tokens = @tokenize.tokenize("\"quoted key\".\"another quoted\"")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -47,7 +47,7 @@ test "parse_dotted_key - string keys" {
 test "parse_dotted_key - integer keys" {
   // Test parsing integer keys - note these will be tokenized as floats
   let tokens = @tokenize.tokenize("123.456.789")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -61,7 +61,7 @@ test "parse_dotted_key - integer keys" {
 test "parse_dotted_key - string and integer mixed" {
   // Test parsing string followed by integer
   let tokens = @tokenize.tokenize("\"key\".123")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -75,7 +75,7 @@ test "parse_dotted_key - string and integer mixed" {
 test "parse_dotted_key - mixed key types" {
   // Test parsing mixed key types
   let tokens = @tokenize.tokenize("server.\"port number\".config")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -90,7 +90,7 @@ test "parse_dotted_key - float token as dotted keys" {
   // Test the special case where tokenizer sees "1.2" as a float
   // but we need to treat it as dotted keys "1.2"
   let tokens = @tokenize.tokenize("1.2")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -104,7 +104,7 @@ test "parse_dotted_key - float token as dotted keys" {
 test "parse_dotted_key - float token with additional dots" {
   // Test float token followed by more dotted keys
   let tokens = @tokenize.tokenize("1.2.config.value")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -119,7 +119,7 @@ test "parse_dotted_key - float token without dot" {
   // Test float token that doesn't actually contain a dot (edge case)
   // We'll use a simpler test with a float that gets parsed as a single key
   let tokens = @tokenize.tokenize("42.0")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -133,7 +133,7 @@ test "parse_dotted_key - float token without dot" {
 test "parse_dotted_key - complex nested structure" {
   // Test a complex real-world-like dotted key
   let tokens = @tokenize.tokenize("database.connections.\"primary-db\".host")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -147,7 +147,7 @@ test "parse_dotted_key - complex nested structure" {
 test "parse_dotted_key - single quoted string" {
   // Test single quoted string key
   let tokens = @tokenize.tokenize("\"key\"")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -161,7 +161,7 @@ test "parse_dotted_key - single quoted string" {
 test "parse_dotted_key - single integer" {
   // Test single integer key
   let tokens = @tokenize.tokenize("42")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -175,7 +175,7 @@ test "parse_dotted_key - single integer" {
 test "parse_dotted_key - error cases" {
   // Test error when no key is found
   let tokens = @tokenize.tokenize("=")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   guard (try parser.parse_dotted_key() catch {
       err => Err(err)
     } noraise {
@@ -200,7 +200,7 @@ test "parse_dotted_key - error cases" {
 test "parse_dotted_key - error after dot" {
   // Test error when dot is followed by invalid token
   let tokens = @tokenize.tokenize("key.=")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   guard (try parser.parse_dotted_key() catch {
       err => Err(err)
     } noraise {
@@ -225,7 +225,7 @@ test "parse_dotted_key - error after dot" {
 test "parse_dotted_key - numeric float with continuation" {
   // Test numeric float like "3.14" followed by more keys
   let tokens = @tokenize.tokenize("3.14.config")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,
@@ -239,7 +239,7 @@ test "parse_dotted_key - numeric float with continuation" {
 test "parse_dotted_key - zero values" {
   // Test with zero values in keys
   let tokens = @tokenize.tokenize("0.0.config")
-  let parser = Parser::new(tokens)
+  let parser = Parser::Parser(tokens)
   let result = parser.parse_dotted_key()
   debug_inspect(
     result,

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub struct Parser {
   tokens : Array[@tokenize.Token]
   mut position : Int
 } derive(@debug.Debug)
-pub fn Parser::new(Array[@tokenize.Token]) -> Self
+pub fn Parser::Parser(Array[@tokenize.Token]) -> Self
 pub fn Parser::update_view(Self, ArrayView[@tokenize.Token]) -> Unit
 pub fn Parser::view(Self, skip_newlines? : Bool) -> ArrayView[@tokenize.Token]
 

--- a/toml.mbt
+++ b/toml.mbt
@@ -77,7 +77,7 @@ pub fn Parser::update_view(
 
 ///|
 /// Create a new parser
-pub fn Parser::new(tokens : Array[@tokenize.Token]) -> Parser {
+pub fn Parser::Parser(tokens : Array[@tokenize.Token]) -> Parser {
   { tokens, position: 0 }
 }
 

--- a/toml_test.mbt
+++ b/toml_test.mbt
@@ -336,7 +336,7 @@ test "parser creation" {
     Equals(loc~),
     StringToken("value", loc~, multiline=false),
   ]
-  let parser = @toml.Parser::new(tokens)
+  let parser = @toml.Parser::Parser(tokens)
   debug_inspect(parser.position, content="0")
   debug_inspect(parser.tokens.length(), content="3")
 }


### PR DESCRIPTION
## Summary
- Renames `Lexer::new` → `Lexer::Lexer` and `Parser::new` → `Parser::Parser` to use MoonBit's type-name constructor convention.
- `moon ide rename --apply` handled the code (54 edits across 9 files); docstring examples and `lexer/README.mbt.md` were updated manually.
- `pkg.generated.mbti` regenerated: `Lexer` now surfaces as `pub struct Lexer { // private fields }` (rather than opaque `type Lexer`) because the same-name constructor is the public way to build it.

## Test plan
- [x] `moon fmt`
- [x] `moon check` — 0 warnings, 0 errors
- [x] `moon test` — 397/397 passing
- [x] `moon info` — `.mbti` regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)