### PR TITLE
chore: enable +a warnings (minus 5 noisy ones), bump to 0.3.0

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/toml"
 
-version = "0.2.3"
+version = "0.3.0"
 
 import {
   "bobzhang/lexer@0.1.3",
@@ -18,4 +18,4 @@ keywords = [ "toml", "parser", "config" ]
 
 description = "A TOML parser implementation in MoonBit"
 
-warnings = "+unnecessary_annotation"
+warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match"


### PR DESCRIPTION
## Summary
- Switch \`moon.mod\` \`warnings\` from \`+unnecessary_annotation\` (opt-in one) to \`+a-…\` (opt-out a few). Five mnemonics are subtracted:
  - \`unused_optional_argument\` (E0031)
  - \`unused_default_value\` (E0032)
  - \`missing_invariant\` (E0038)
  - \`missing_reasoning\` (E0039)
  - \`lexmatch_longest_match\` (E0077)
- Bump \`0.2.3\` → \`0.3.0\`. Previous release exposed \`pub struct Parser\` plus \`Parser::new\`, \`Parser::view\`, \`Parser::update_view\`. Those were made private in PRs #96/#97, so the public API of \`bobzhang/toml\` shrank to \`parse(String) -> TomlValue raise\` and \`TomlValue\` + its methods. A removal from the public surface → minor bump under 0.x semantics.

## Test plan
- [x] \`moon check\` — 0 warnings, 0 errors
- [x] \`moon check --deny-warn\` — clean (what CI runs)
- [x] \`moon test\` — 397/397 passing
- [x] \`moon info\` — \`.mbti\` unchanged

## Follow-up
After merge, tag \`v0.3.0\` on \`main\` and cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)