### PR TITLE
chore: bump to 0.4.0

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/toml"
 
-version = "0.3.0"
+version = "0.4.0"
 
 import {
   "bobzhang/lexer@0.1.3",


### PR DESCRIPTION
## Summary
Version bump for the TomlDateTime extraction landed in PR #99:
- New public sub-package \`bobzhang/toml/datetime\` owns the type.
- Root re-exports via \`pub using @datetime { type TomlDateTime }\`, so \`@toml.TomlDateTime\` still resolves.
- Public \`.mbti\` no longer mentions \`@tokenize\`.

The payload qualifier in \`TomlValue::TomlDateTime\` changed from \`@tokenize.TomlDateTime\` to \`@datetime.TomlDateTime\`. External users reaching into \`internal/tokenize\` directly (against convention) would need to repoint imports.

## Test plan
- [x] \`moon check --deny-warn\`
- [x] \`moon test\` — 397/397
- [x] \`moon info\`

Tag \`v0.4.0\` will be created on \`main\` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)