### PR TITLE
Upgrade moonbitlang/async to 0.20.2 and clear all moon check warnings

### DIFF
--- a/cmd/toml/main.mbt
+++ b/cmd/toml/main.mbt
@@ -40,7 +40,7 @@ fn main {
 
 ///|
 fn run(args : ArrayView[String]) -> Int {
-  let matches = @argparse.parse(toml_command(), argv=args, env={}) catch {
+  let matches = @argparse.parse(toml_command(), argv=args, env=Map([])) catch {
     err => {
       println(err)
       return 2

--- a/cmd/toml/moon.pkg
+++ b/cmd/toml/moon.pkg
@@ -6,6 +6,4 @@ import {
   "moonbitlang/x/sys",
 }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/datetime/datetime.mbt
+++ b/datetime/datetime.mbt
@@ -18,6 +18,15 @@ pub(all) enum TomlDateTime {
 } derive(Eq, Debug)
 
 ///|
+pub extend TomlDateTime with Eq::{not_equal, equal}
+
+///|
+pub extend TomlDateTime with Debug::{to_repr}
+
+///|
+pub extend TomlDateTime with Show::{to_string, output}
+
+///|
 /// Render the variant for human-readable diagnostics:
 /// `OffsetDateTime("1979-05-27T07:32:00Z")` etc.
 pub impl Show for TomlDateTime with fn output(self, logger) {

--- a/datetime/pkg.generated.mbti
+++ b/datetime/pkg.generated.mbti
@@ -16,6 +16,12 @@ pub(all) enum TomlDateTime {
   LocalDate(String)
   LocalTime(String)
 } derive(Eq, @debug.Debug)
+pub fn TomlDateTime::equal(Self, Self) -> Bool
+pub fn TomlDateTime::not_equal(Self, Self) -> Bool
+pub fn TomlDateTime::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn TomlDateTime::to_repr(Self) -> @debug.Repr
+pub fn TomlDateTime::to_string(Self) -> String
 pub impl Show for TomlDateTime
 
 // Type aliases

--- a/e2e/convert.mbt
+++ b/e2e/convert.mbt
@@ -27,7 +27,7 @@ pub fn to_test_json(value : @toml.TomlValue) -> Json {
 
 ///|
 fn typed_value(ty : String, value : String) -> Json {
-  let obj : Map[String, Json] = {}
+  let obj : Map[String, Json] = Map([])
   obj["type"] = Json::string(ty)
   obj["value"] = Json::string(value)
   Json::object(obj)

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -5,7 +5,7 @@ version = "0.1.0"
 import {
   "bobzhang/toml@0.4.0",
   "moonbitlang/x@0.4.41",
-  "moonbitlang/async@0.16.8",
+  "moonbitlang/async@0.20.2",
 }
 
 warnings = "+test_unqualified_package"

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -32,6 +32,24 @@ pub(all) enum SimpleValue {
 } derive(Eq, Debug)
 
 ///|
+pub extend SimpleDocument with Eq::{not_equal, equal}
+
+///|
+pub extend SimpleDocument with Debug::{to_repr}
+
+///|
+pub extend SimpleDocument with Show::{to_string, output}
+
+///|
+pub extend SimpleValue with Eq::{not_equal, equal}
+
+///|
+pub extend SimpleValue with Debug::{to_repr}
+
+///|
+pub extend SimpleValue with Show::{to_string, output}
+
+///|
 pub impl Show for SimpleDocument with fn output(self, logger) {
   Debug::to_repr(self).output(logger)
 }

--- a/internal/qc_model/pkg.generated.mbti
+++ b/internal/qc_model/pkg.generated.mbti
@@ -23,7 +23,13 @@ pub fn SimpleDocument::contains_fractional_datetime(Self) -> Bool
 pub fn SimpleDocument::contains_negative_exponent_like_key(Self) -> Bool
 pub fn SimpleDocument::contains_string(Self) -> Bool
 pub fn SimpleDocument::contains_table(Self) -> Bool
+pub fn SimpleDocument::equal(Self, Self) -> Bool
 pub fn SimpleDocument::from_toml(@toml.TomlValue) -> Self?
+pub fn SimpleDocument::not_equal(Self, Self) -> Bool
+pub fn SimpleDocument::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn SimpleDocument::to_repr(Self) -> @debug.Repr
+pub fn SimpleDocument::to_string(Self) -> String
 pub fn SimpleDocument::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleDocument
 
@@ -39,7 +45,13 @@ pub(all) enum SimpleValue {
   SBooleanArray(Array[Bool])
   STable(Map[String, SimpleValue])
 } derive(Eq, @debug.Debug)
+pub fn SimpleValue::equal(Self, Self) -> Bool
 pub fn SimpleValue::from_toml(@toml.TomlValue) -> Self?
+pub fn SimpleValue::not_equal(Self, Self) -> Bool
+pub fn SimpleValue::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn SimpleValue::to_repr(Self) -> @debug.Repr
+pub fn SimpleValue::to_string(Self) -> String
 pub fn SimpleValue::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleValue
 

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -20,6 +20,10 @@ pub(all) struct Loc {
   end : @lexer.Position
 } derive(Eq, @debug.Debug)
 pub fn Loc::adjacent(Self, Self) -> Bool
+pub fn Loc::equal(Self, Self) -> Bool
+pub fn Loc::not_equal(Self, Self) -> Bool
+#as_free_fn
+pub fn Loc::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Token {
   StringToken(String, loc~ : Loc, multiline~ : Bool)
@@ -38,7 +42,11 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, @debug.Debug)
+pub fn Token::equal(Self, Self) -> Bool
 pub fn Token::loc(Self) -> Loc
+pub fn Token::not_equal(Self, Self) -> Bool
+#as_free_fn
+pub fn Token::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -12,6 +12,12 @@ pub(all) struct Loc {
 } derive(Eq, Debug)
 
 ///|
+pub extend Loc with Eq::{not_equal, equal}
+
+///|
+pub extend Loc with Debug::{to_repr}
+
+///|
 /// Token types for the lexer
 pub(all) enum Token {
   // Literals
@@ -37,6 +43,12 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, Debug)
+
+///|
+pub extend Token with Eq::{not_equal, equal}
+
+///|
+pub extend Token with Debug::{to_repr}
 
 ///|
 /// Check if two locations are adjacent (end of first equals start of second).

--- a/parser.mbt
+++ b/parser.mbt
@@ -137,7 +137,7 @@ fn Parser::parse_array(self : Self) -> TomlValue raise {
 /// Parse an inline table {key = value, key2 = value2}
 /// No trailing comma allowed unlike Array
 fn Parser::parse_inline_table(self : Parser) -> TomlValue raise {
-  let table = {}
+  let table = Map([])
   self.skip_newlines() // TOML 1.1: allow newlines in inline tables
   if self.view() is [RightBrace, .. rest] {
     self.update_view(rest)
@@ -300,7 +300,7 @@ let header_defined_marker : String = "\u0000__header__"
 pub fn parse(input : String) -> TomlValue raise {
   let tokens = @tokenize.tokenize(input)
   let parser = Parser::Parser(tokens)
-  let main_table = {}
+  let main_table = Map([])
   for current_table = main_table {
     parser.skip_newlines()
     match parser.view() {

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -22,7 +22,12 @@ pub(all) enum TomlValue {
   TomlDateTime(@datetime.TomlDateTime)
 } derive(Eq, @debug.Debug)
 pub fn TomlValue::datetime_info(Self) -> (String, String)?
+pub fn TomlValue::equal(Self, Self) -> Bool
 pub fn TomlValue::is_homogeneous_array(Array[Self]) -> Bool
+pub fn TomlValue::not_equal(Self, Self) -> Bool
+pub fn TomlValue::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn TomlValue::to_repr(Self) -> @debug.Repr
 pub fn TomlValue::to_string(Self) -> String
 pub fn TomlValue::type_name(Self) -> String
 pub fn TomlValue::validate(Self) -> Bool

--- a/toml.mbt
+++ b/toml.mbt
@@ -11,6 +11,12 @@ pub(all) enum TomlValue {
 } derive(Eq, Debug)
 
 ///|
+pub extend TomlValue with Eq::{not_equal, equal}
+
+///|
+pub extend TomlValue with Debug::{to_repr}
+
+///|
 /// Re-export `TomlDateTime` so consumers see the type as `@toml.TomlDateTime`
 /// instead of having to import the `datetime` subpackage directly.
 pub using @datetime {type TomlDateTime}

--- a/toml_to_string.mbt
+++ b/toml_to_string.mbt
@@ -118,6 +118,9 @@ pub fn TomlValue::to_string(self : TomlValue) -> String {
 }
 
 ///|
+pub extend TomlValue with Show::{output}
+
+///|
 /// TODO: the logger interface is good?
 pub impl Show for TomlValue with fn output(self, logger) {
   logger.write_string(self.to_string())

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -47,24 +47,32 @@ priv suberror TableConflicts {
   ExpectedArray(String, TomlValue)
   DuplicateKey(String)
   InlineTableImmutable(String)
-} derive(Debug)
+}
 
 ///|
-/// Show impl for error messages
-impl Show for TableConflicts with fn output(self, logger) {
+/// Render a conflict for parser diagnostics.
+///
+/// This is a plain method rather than a `Show`/`Debug` impl: `TableConflicts`
+/// is private, so a trait impl's methods would be promoted to regular methods
+/// that nothing calls, which the compiler reports as dead code.
+fn TableConflicts::to_string(self : TableConflicts) -> String {
   match self {
     ExpectedTable(key, value) =>
-      logger <+
+      (
         $|ExpectedTable("\{key}", "\{value.type_name()}")
+      )
     ExpectedArray(key, value) =>
-      logger <+
+      (
         $|ExpectedArray("\{key}", "\{value.type_name()}")
+      )
     DuplicateKey(key) =>
-      logger <+
+      (
         $|DuplicateKey("\{key}")
+      )
     InlineTableImmutable(key) =>
-      logger <+
+      (
         $|InlineTableImmutable("\{key}")
+      )
   }
 }
 
@@ -130,7 +138,7 @@ fn create_array_of_tables(
 
   // Handle the final key as an array of tables
   let final_key = path[path.length() - 1]
-  let new_table = {}
+  let new_table = Map([])
   match current_table.get(final_key) {
     Some(TomlArray(existing_array)) => {
       // Verify this is an array-of-tables (created by [[ ]]), not a static array (= [...])
@@ -157,7 +165,7 @@ fn create_array_of_tables(
 ///|
 test "create_array_of_tables - first table creation" {
   // Test creating the first table in an array of tables
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create first table in array [[servers]]
   let new_table = create_array_of_tables(root_table, ["servers"])
@@ -179,7 +187,7 @@ test "create_array_of_tables - first table creation" {
 ///|
 test "create_array_of_tables - append to existing array" {
   // Test appending to an existing array of tables
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create first table
   let table1 = create_array_of_tables(root_table, ["products"])
@@ -217,7 +225,7 @@ test "create_array_of_tables - append to existing array" {
 ///|
 test "create_array_of_tables - nested path creation" {
   // Test creating array of tables with nested path
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create [[fruit.physical.color]]
   let color_table1 = create_array_of_tables(root_table, [
@@ -299,7 +307,7 @@ test "create_array_of_tables - path conflicts with non-table" {
   let result = try
     create_array_of_tables(root_table, ["products", "items"])
   catch {
-    err => Err(err)
+    err => Err(err.to_string())
   } noraise {
     value => Ok(value)
   }
@@ -328,7 +336,7 @@ test "create_array_of_tables - final key conflicts with non-array" {
   let result = try
     create_array_of_tables(root_table, ["servers", "alpha"])
   catch {
-    err => Err(err)
+    err => Err(err.to_string())
   } noraise {
     value => Ok(value)
   }
@@ -560,14 +568,13 @@ test "set dotted key value - reject duplicate key" {
   let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["config", "timeout"], TomlInteger(30))
   // Duplicate key should be rejected
-  let result = try
+  try
     set_dotted_key_value(table, ["config", "timeout"], TomlInteger(60))
   catch {
-    err => Err(err)
+    err => inspect(err.to_string(), content="DuplicateKey(\"timeout\")")
   } noraise {
-    value => Ok(value)
+    _ => fail("Expected error but got success")
   }
-  debug_inspect(result, content="Err(DuplicateKey(\"timeout\"))")
 }
 
 ///|
@@ -601,7 +608,7 @@ test "set dotted key value - add to existing table" {
 
 ///|
 test "set dotted key value - conflict with non-table value" {
-  let table : Map[String, TomlValue] = {}
+  let table : Map[String, TomlValue] = Map([])
 
   // Set a string value at "config"
   set_dotted_key_value(table, ["config"], TomlString("simple value"))
@@ -611,10 +618,10 @@ test "set dotted key value - conflict with non-table value" {
     set_dotted_key_value(table, ["config", "nested"], TomlString("value"))
   catch {
     err =>
-      debug_inspect(
-        err,
+      inspect(
+        err.to_string(),
         content=(
-          #|ExpectedTable("config", TomlString("simple value"))
+          #|ExpectedTable("config", "string")
         ),
       )
   } noraise {


### PR DESCRIPTION
## Summary

Upgrades `moonbitlang/async` in the e2e module and clears every `moon check` warning in the workspace.

Two independent breakages on the **current stable toolchain** (moon `0.1.20260713` / moonc `v0.10.4`, which is exactly what CI installs):

1. **async 0.16.8 no longer compiles.** `moon check` failed *inside the dependency*: `The type IterResult is undefined` at `.mooncakes/moonbitlang/async/src/task_group.mbt:303`. `moon add --upgrade moonbitlang/async` -> **0.20.2**, which builds clean.
2. **27 warnings, and CI runs `moon check --deny-warn`.** These are pre-existing toolchain drift, entirely unrelated to async.

On the second point — to be precise about the state of `main`: its last CI run (`73f18e3`, 2026-07-08) **passed**, but that predates the 2026-07-13 stable release. Checking out `origin/main` and running today's stable locally reproduces **27 warnings + 1 error**, so `main` would go red on its next run regardless of this bump. This PR fixes that too.

## Warning fixes

| Warning | Count | Fix |
|---|---|---|
| `implicit_impl_as_method` (0079) | 18 | explicit `extend` declarations |
| `ambiguous_braces` (0082) | 9 | bare `{}` -> `Map([])` |

**`implicit_impl_as_method`** — trait impls are still implicitly promoted to regular methods, which is deprecated and slated for removal. Declaring the promotion explicitly with `pub extend` on the public types (`TomlValue`, `TomlDateTime`, `Loc`, `Token`, `SimpleValue`, `SimpleDocument`) keeps `.to_string()` / `.equal()` working for downstream users once the implicit behavior goes away. These methods were **already callable** via the implicit promotion, so the `.mbti` additions document the existing surface rather than widening it.

**`ambiguous_braces`** — `Map([])` is already the idiom in `toml_utils.mbt`; these were stragglers.

### `TableConflicts` needed a different approach

It is `priv`, which makes it unwinnable either way: adding `extend` promotes trait methods into regular methods nothing calls (`unused_value`), and omitting `extend` leaves the implicit promotion (`0079`). Confirmed against the diagnostic docs — `unused_value` fires when a function is *"not used by any other part of your code, nor marked with `pub`"*.

Since the parser only ever renders it via `error.to_string()`, the `Show`/`Debug` impls are replaced with a plain `to_string` method. The alternative — making the type public — would have leaked an internal conflict-detection error into the library's public API, cutting against this repo's recent `priv` refactors.

- User-facing parser messages are **unchanged** (`parser_test.mbt` snapshots pass untouched).
- Two inline tests that asserted on the derived `Debug` repr now assert on `to_string()`, so `ExpectedTable("config", TomlString("simple value"))` becomes `ExpectedTable("config", "string")`.

## Note on `cmd/toml/moon.pkg`

The diff includes moon's automatic `options("is-main": true)` -> `pkgtype(kind: "executable")` rewrite. This is applied by the same stable toolchain during `moon fmt`/`moon info` — CI checks both with `git diff --exit-code`, so it has to be committed or CI fails. Verified idempotent, and `lexer/moon.pkg`'s `options(name:)` is not part of that migration.

## Verification

Ran the full CI gate sequence locally, and CI is green on both jobs:

- `moon check --deny-warn` — clean (was: 27 warnings, 1 error)
- `moon fmt` / `moon info` — idempotent, no residual diff
- `moon test .` — 243/243 pass
- e2e — **397/397 pass** (exercises the upgraded async directly; note CI's `moon test .` does not cover the e2e module)
- `moon cram test --release tests/cram` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)