### PR TITLE
Upgrade moonbitlang/async to 0.20.2 and fix ambiguous_braces warnings

### DIFF
--- a/cmd/toml/main.mbt
+++ b/cmd/toml/main.mbt
@@ -40,7 +40,7 @@ fn main {
 
 ///|
 fn run(args : ArrayView[String]) -> Int {
-  let matches = @argparse.parse(toml_command(), argv=args, env={}) catch {
+  let matches = @argparse.parse(toml_command(), argv=args, env=Map([])) catch {
     err => {
       println(err)
       return 2

--- a/cmd/toml/moon.pkg
+++ b/cmd/toml/moon.pkg
@@ -6,6 +6,4 @@ import {
   "moonbitlang/x/sys",
 }
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/e2e/convert.mbt
+++ b/e2e/convert.mbt
@@ -27,7 +27,7 @@ pub fn to_test_json(value : @toml.TomlValue) -> Json {
 
 ///|
 fn typed_value(ty : String, value : String) -> Json {
-  let obj : Map[String, Json] = {}
+  let obj : Map[String, Json] = Map([])
   obj["type"] = Json::string(ty)
   obj["value"] = Json::string(value)
   Json::object(obj)

--- a/e2e/moon.mod
+++ b/e2e/moon.mod
@@ -5,7 +5,7 @@ version = "0.1.0"
 import {
   "bobzhang/toml@0.4.0",
   "moonbitlang/x@0.4.41",
-  "moonbitlang/async@0.16.8",
+  "moonbitlang/async@0.20.2",
 }
 
 warnings = "+test_unqualified_package"

--- a/moon.mod
+++ b/moon.mod
@@ -18,4 +18,4 @@ keywords = [ "toml", "parser", "config" ]
 
 description = "A TOML parser implementation in MoonBit"
 
-warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match"
+warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match-implicit_impl_as_method"

--- a/parser.mbt
+++ b/parser.mbt
@@ -137,7 +137,7 @@ fn Parser::parse_array(self : Self) -> TomlValue raise {
 /// Parse an inline table {key = value, key2 = value2}
 /// No trailing comma allowed unlike Array
 fn Parser::parse_inline_table(self : Parser) -> TomlValue raise {
-  let table = {}
+  let table = Map([])
   self.skip_newlines() // TOML 1.1: allow newlines in inline tables
   if self.view() is [RightBrace, .. rest] {
     self.update_view(rest)
@@ -300,7 +300,7 @@ let header_defined_marker : String = "\u0000__header__"
 pub fn parse(input : String) -> TomlValue raise {
   let tokens = @tokenize.tokenize(input)
   let parser = Parser::Parser(tokens)
-  let main_table = {}
+  let main_table = Map([])
   for current_table = main_table {
     parser.skip_newlines()
     match parser.view() {

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -130,7 +130,7 @@ fn create_array_of_tables(
 
   // Handle the final key as an array of tables
   let final_key = path[path.length() - 1]
-  let new_table = {}
+  let new_table = Map([])
   match current_table.get(final_key) {
     Some(TomlArray(existing_array)) => {
       // Verify this is an array-of-tables (created by [[ ]]), not a static array (= [...])
@@ -157,7 +157,7 @@ fn create_array_of_tables(
 ///|
 test "create_array_of_tables - first table creation" {
   // Test creating the first table in an array of tables
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create first table in array [[servers]]
   let new_table = create_array_of_tables(root_table, ["servers"])
@@ -179,7 +179,7 @@ test "create_array_of_tables - first table creation" {
 ///|
 test "create_array_of_tables - append to existing array" {
   // Test appending to an existing array of tables
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create first table
   let table1 = create_array_of_tables(root_table, ["products"])
@@ -217,7 +217,7 @@ test "create_array_of_tables - append to existing array" {
 ///|
 test "create_array_of_tables - nested path creation" {
   // Test creating array of tables with nested path
-  let root_table : Map[String, TomlValue] = {}
+  let root_table : Map[String, TomlValue] = Map([])
 
   // Create [[fruit.physical.color]]
   let color_table1 = create_array_of_tables(root_table, [
@@ -601,7 +601,7 @@ test "set dotted key value - add to existing table" {
 
 ///|
 test "set dotted key value - conflict with non-table value" {
-  let table : Map[String, TomlValue] = {}
+  let table : Map[String, TomlValue] = Map([])
 
   // Set a string value at "config"
   set_dotted_key_value(table, ["config"], TomlString("simple value"))


### PR DESCRIPTION
## Summary

Part 1 of 2. The low-risk half: unbreak the build and clear the mechanical warnings. **No public API change** — `.mbti` files are untouched.

The follow-up PR handles `implicit_impl_as_method`, which does change the generated `.mbti` and deserves its own review.

### 1. async 0.16.8 -> 0.20.2

The pinned version no longer compiles on the current stable toolchain. `moon check` failed *inside the dependency itself*:

```
Error: [4032] The type IterResult is undefined
  .mooncakes/moonbitlang/async/src/task_group.mbt:303:19
```

`moon add --upgrade moonbitlang/async` -> **0.20.2**, which builds clean. All 397 e2e tests pass against it.

### 2. `ambiguous_braces` (9)

Bare `{}` -> `Map([])`, which is already the idiom elsewhere in `toml_utils.mbt` — these were stragglers.

## Why `implicit_impl_as_method` is deferred

The current stable toolchain (moon `0.1.20260713` / moonc `v0.10.4`, exactly what CI installs) reports **27 warnings** on this repo, and CI runs `moon check --deny-warn`. This PR fixes 9 of them; the other 18 are `implicit_impl_as_method`.

So that this change can land on its own, those 18 are temporarily silenced with `-implicit_impl_as_method` in `moon.mod`. **The follow-up PR adds the `extend` declarations and removes that line** — it is deliberately a one-line, easily-reverted marker rather than a permanent config change.

On the state of `main`: its last CI run (`73f18e3`, 2026-07-08) passed, but that predates the 2026-07-13 stable release. Checking out `origin/main` and running today's stable locally reproduces 27 warnings + 1 error, so `main` would go red on its next run regardless of this bump.

## Note on `cmd/toml/moon.pkg`

The diff includes moon's automatic `options("is-main": true)` -> `pkgtype(kind: "executable")` rewrite. The same stable toolchain applies it during `moon fmt`/`moon info`, and CI checks both with `git diff --exit-code`, so it has to be committed or CI fails. Verified idempotent; `lexer/moon.pkg`'s `options(name:)` is not part of that migration.

## Verification

Full CI gate sequence run locally:

- `moon check --deny-warn` — clean
- `moon fmt` / `moon info` — idempotent, no residual diff, **no `.mbti` changes**
- `moon test .` — 243/243 pass
- e2e — **397/397 pass** (exercises the upgraded async directly; CI's `moon test .` does not cover the e2e module)
- `moon cram test --release tests/cram` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)