### PR TITLE
Declare impl-to-method promotion explicitly and re-enable the warning

### DIFF
--- a/datetime/datetime.mbt
+++ b/datetime/datetime.mbt
@@ -18,6 +18,15 @@ pub(all) enum TomlDateTime {
 } derive(Eq, Debug)
 
 ///|
+pub extend TomlDateTime with Eq::{not_equal, equal}
+
+///|
+pub extend TomlDateTime with Debug::{to_repr}
+
+///|
+pub extend TomlDateTime with Show::{to_string, output}
+
+///|
 /// Render the variant for human-readable diagnostics:
 /// `OffsetDateTime("1979-05-27T07:32:00Z")` etc.
 pub impl Show for TomlDateTime with fn output(self, logger) {

--- a/datetime/pkg.generated.mbti
+++ b/datetime/pkg.generated.mbti
@@ -16,6 +16,12 @@ pub(all) enum TomlDateTime {
   LocalDate(String)
   LocalTime(String)
 } derive(Eq, @debug.Debug)
+pub fn TomlDateTime::equal(Self, Self) -> Bool
+pub fn TomlDateTime::not_equal(Self, Self) -> Bool
+pub fn TomlDateTime::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn TomlDateTime::to_repr(Self) -> @debug.Repr
+pub fn TomlDateTime::to_string(Self) -> String
 pub impl Show for TomlDateTime
 
 // Type aliases

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -32,6 +32,24 @@ pub(all) enum SimpleValue {
 } derive(Eq, Debug)
 
 ///|
+pub extend SimpleDocument with Eq::{not_equal, equal}
+
+///|
+pub extend SimpleDocument with Debug::{to_repr}
+
+///|
+pub extend SimpleDocument with Show::{to_string, output}
+
+///|
+pub extend SimpleValue with Eq::{not_equal, equal}
+
+///|
+pub extend SimpleValue with Debug::{to_repr}
+
+///|
+pub extend SimpleValue with Show::{to_string, output}
+
+///|
 pub impl Show for SimpleDocument with fn output(self, logger) {
   Debug::to_repr(self).output(logger)
 }

--- a/internal/qc_model/pkg.generated.mbti
+++ b/internal/qc_model/pkg.generated.mbti
@@ -23,7 +23,13 @@ pub fn SimpleDocument::contains_fractional_datetime(Self) -> Bool
 pub fn SimpleDocument::contains_negative_exponent_like_key(Self) -> Bool
 pub fn SimpleDocument::contains_string(Self) -> Bool
 pub fn SimpleDocument::contains_table(Self) -> Bool
+pub fn SimpleDocument::equal(Self, Self) -> Bool
 pub fn SimpleDocument::from_toml(@toml.TomlValue) -> Self?
+pub fn SimpleDocument::not_equal(Self, Self) -> Bool
+pub fn SimpleDocument::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn SimpleDocument::to_repr(Self) -> @debug.Repr
+pub fn SimpleDocument::to_string(Self) -> String
 pub fn SimpleDocument::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleDocument
 
@@ -39,7 +45,13 @@ pub(all) enum SimpleValue {
   SBooleanArray(Array[Bool])
   STable(Map[String, SimpleValue])
 } derive(Eq, @debug.Debug)
+pub fn SimpleValue::equal(Self, Self) -> Bool
 pub fn SimpleValue::from_toml(@toml.TomlValue) -> Self?
+pub fn SimpleValue::not_equal(Self, Self) -> Bool
+pub fn SimpleValue::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn SimpleValue::to_repr(Self) -> @debug.Repr
+pub fn SimpleValue::to_string(Self) -> String
 pub fn SimpleValue::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleValue
 

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -20,6 +20,10 @@ pub(all) struct Loc {
   end : @lexer.Position
 } derive(Eq, @debug.Debug)
 pub fn Loc::adjacent(Self, Self) -> Bool
+pub fn Loc::equal(Self, Self) -> Bool
+pub fn Loc::not_equal(Self, Self) -> Bool
+#as_free_fn
+pub fn Loc::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Token {
   StringToken(String, loc~ : Loc, multiline~ : Bool)
@@ -38,7 +42,11 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, @debug.Debug)
+pub fn Token::equal(Self, Self) -> Bool
 pub fn Token::loc(Self) -> Loc
+pub fn Token::not_equal(Self, Self) -> Bool
+#as_free_fn
+pub fn Token::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -12,6 +12,12 @@ pub(all) struct Loc {
 } derive(Eq, Debug)
 
 ///|
+pub extend Loc with Eq::{not_equal, equal}
+
+///|
+pub extend Loc with Debug::{to_repr}
+
+///|
 /// Token types for the lexer
 pub(all) enum Token {
   // Literals
@@ -37,6 +43,12 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, Debug)
+
+///|
+pub extend Token with Eq::{not_equal, equal}
+
+///|
+pub extend Token with Debug::{to_repr}
 
 ///|
 /// Check if two locations are adjacent (end of first equals start of second).

--- a/moon.mod
+++ b/moon.mod
@@ -18,4 +18,4 @@ keywords = [ "toml", "parser", "config" ]
 
 description = "A TOML parser implementation in MoonBit"
 
-warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match-implicit_impl_as_method"
+warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match"

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -22,7 +22,12 @@ pub(all) enum TomlValue {
   TomlDateTime(@datetime.TomlDateTime)
 } derive(Eq, @debug.Debug)
 pub fn TomlValue::datetime_info(Self) -> (String, String)?
+pub fn TomlValue::equal(Self, Self) -> Bool
 pub fn TomlValue::is_homogeneous_array(Array[Self]) -> Bool
+pub fn TomlValue::not_equal(Self, Self) -> Bool
+pub fn TomlValue::output(Self, &Logger) -> Unit
+#as_free_fn
+pub fn TomlValue::to_repr(Self) -> @debug.Repr
 pub fn TomlValue::to_string(Self) -> String
 pub fn TomlValue::type_name(Self) -> String
 pub fn TomlValue::validate(Self) -> Bool

--- a/toml.mbt
+++ b/toml.mbt
@@ -11,6 +11,12 @@ pub(all) enum TomlValue {
 } derive(Eq, Debug)
 
 ///|
+pub extend TomlValue with Eq::{not_equal, equal}
+
+///|
+pub extend TomlValue with Debug::{to_repr}
+
+///|
 /// Re-export `TomlDateTime` so consumers see the type as `@toml.TomlDateTime`
 /// instead of having to import the `datetime` subpackage directly.
 pub using @datetime {type TomlDateTime}

--- a/toml_to_string.mbt
+++ b/toml_to_string.mbt
@@ -118,6 +118,9 @@ pub fn TomlValue::to_string(self : TomlValue) -> String {
 }
 
 ///|
+pub extend TomlValue with Show::{output}
+
+///|
 /// TODO: the logger interface is good?
 pub impl Show for TomlValue with fn output(self, logger) {
   logger.write_string(self.to_string())

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -47,24 +47,32 @@ priv suberror TableConflicts {
   ExpectedArray(String, TomlValue)
   DuplicateKey(String)
   InlineTableImmutable(String)
-} derive(Debug)
+}
 
 ///|
-/// Show impl for error messages
-impl Show for TableConflicts with fn output(self, logger) {
+/// Render a conflict for parser diagnostics.
+///
+/// This is a plain method rather than a `Show`/`Debug` impl: `TableConflicts`
+/// is private, so a trait impl's methods would be promoted to regular methods
+/// that nothing calls, which the compiler reports as dead code.
+fn TableConflicts::to_string(self : TableConflicts) -> String {
   match self {
     ExpectedTable(key, value) =>
-      logger <+
+      (
         $|ExpectedTable("\{key}", "\{value.type_name()}")
+      )
     ExpectedArray(key, value) =>
-      logger <+
+      (
         $|ExpectedArray("\{key}", "\{value.type_name()}")
+      )
     DuplicateKey(key) =>
-      logger <+
+      (
         $|DuplicateKey("\{key}")
+      )
     InlineTableImmutable(key) =>
-      logger <+
+      (
         $|InlineTableImmutable("\{key}")
+      )
   }
 }
 
@@ -299,7 +307,7 @@ test "create_array_of_tables - path conflicts with non-table" {
   let result = try
     create_array_of_tables(root_table, ["products", "items"])
   catch {
-    err => Err(err)
+    err => Err(err.to_string())
   } noraise {
     value => Ok(value)
   }
@@ -328,7 +336,7 @@ test "create_array_of_tables - final key conflicts with non-array" {
   let result = try
     create_array_of_tables(root_table, ["servers", "alpha"])
   catch {
-    err => Err(err)
+    err => Err(err.to_string())
   } noraise {
     value => Ok(value)
   }
@@ -560,14 +568,13 @@ test "set dotted key value - reject duplicate key" {
   let table : Map[String, TomlValue] = Map([])
   set_dotted_key_value(table, ["config", "timeout"], TomlInteger(30))
   // Duplicate key should be rejected
-  let result = try
+  try
     set_dotted_key_value(table, ["config", "timeout"], TomlInteger(60))
   catch {
-    err => Err(err)
+    err => inspect(err.to_string(), content="DuplicateKey(\"timeout\")")
   } noraise {
-    value => Ok(value)
+    _ => fail("Expected error but got success")
   }
-  debug_inspect(result, content="Err(DuplicateKey(\"timeout\"))")
 }
 
 ///|
@@ -611,10 +618,10 @@ test "set dotted key value - conflict with non-table value" {
     set_dotted_key_value(table, ["config", "nested"], TomlString("value"))
   catch {
     err =>
-      debug_inspect(
-        err,
+      inspect(
+        err.to_string(),
         content=(
-          #|ExpectedTable("config", TomlString("simple value"))
+          #|ExpectedTable("config", "string")
         ),
       )
   } noraise {


### PR DESCRIPTION
## Summary

Part 2 of 2. Stacked on #105 — **please merge that first**; this PR's base will retarget to `main` automatically once it lands, and the diff here shows only the `extend` work.

#105 silenced `implicit_impl_as_method` with a temporary `-implicit_impl_as_method` line so the async bump could land on its own. This fixes those 18 warnings properly and **removes that line**, restoring the full `+a` warning set.

## `implicit_impl_as_method` (18)

Trait impls are still implicitly promoted to regular methods, which is deprecated and slated for removal. Declaring the promotion explicitly with `extend` on the public types (`TomlValue`, `TomlDateTime`, `Loc`, `Token`, `SimpleValue`, `SimpleDocument`) keeps `.to_string()` / `.equal()` working for downstream users once the implicit behavior goes away.

**On the `.mbti` growth:** these methods were *already callable* via the implicit promotion — the additions document the existing surface rather than widening it. Dropping the promotion instead would be the breaking option.

## `TableConflicts` needed a different approach

It is `priv`, which makes it unwinnable either way:

- adding `extend` promotes trait methods into regular methods nothing calls -> `unused_value`
- omitting `extend` leaves the implicit promotion -> `0079`

Confirmed against the diagnostic docs — `unused_value` fires when a function is *"not used by any other part of your code, nor marked with `pub`"*. Verified empirically: making the type `pub` clears both warnings, which isolates visibility as the sole cause.

Since the parser only ever renders it via `error.to_string()`, the `Show`/`Debug` impls are replaced with a plain `to_string` method. The alternative — making the type public — would leak an internal conflict-detection error into the library's public API, cutting against this repo's recent `priv` refactors.

- User-facing parser messages are **unchanged** (`parser_test.mbt` snapshots pass untouched).
- Two inline tests that asserted on the derived `Debug` repr now assert on `to_string()`: `ExpectedTable("config", TomlString("simple value"))` becomes `ExpectedTable("config", "string")`. This is a small, deliberate loss of assertion precision on the payload — flagging it explicitly for review.

## Verification

With `-implicit_impl_as_method` removed and the warning fully re-enabled:

- `moon check --deny-warn` — clean
- `moon fmt` / `moon info` — idempotent, no residual diff
- `moon test .` — 243/243 pass
- e2e — 397/397 pass
- `moon cram test --release tests/cram` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)