### PR TITLE
Declare impl-to-method promotion explicitly and re-enable the warning

### DIFF
--- a/datetime/datetime.mbt
+++ b/datetime/datetime.mbt
@@ -18,6 +18,21 @@ pub(all) enum TomlDateTime {
 } derive(Eq, Debug)
 
 ///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend TomlDateTime with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend TomlDateTime with Debug::{to_repr}
+
+///|
+pub extend TomlDateTime with Show::{to_string}
+
+///|
+#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
+pub extend TomlDateTime with Show::{output}
+
+///|
 /// Render the variant for human-readable diagnostics:
 /// `OffsetDateTime("1979-05-27T07:32:00Z")` etc.
 pub impl Show for TomlDateTime with fn output(self, logger) {

--- a/datetime/pkg.generated.mbti
+++ b/datetime/pkg.generated.mbti
@@ -16,6 +16,16 @@ pub(all) enum TomlDateTime {
   LocalDate(String)
   LocalTime(String)
 } derive(Eq, @debug.Debug)
+#deprecated
+pub fn TomlDateTime::equal(Self, Self) -> Bool
+#deprecated
+pub fn TomlDateTime::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn TomlDateTime::output(Self, &Logger) -> Unit
+#as_free_fn
+#deprecated
+pub fn TomlDateTime::to_repr(Self) -> @debug.Repr
+pub fn TomlDateTime::to_string(Self) -> String
 pub impl Show for TomlDateTime
 
 // Type aliases

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -32,6 +32,30 @@ pub(all) enum SimpleValue {
 } derive(Eq, Debug)
 
 ///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend SimpleDocument with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend SimpleDocument with Debug::{to_repr}
+
+///|
+#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
+pub extend SimpleDocument with Show::{to_string, output}
+
+///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend SimpleValue with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend SimpleValue with Debug::{to_repr}
+
+///|
+#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
+pub extend SimpleValue with Show::{to_string, output}
+
+///|
 pub impl Show for SimpleDocument with fn output(self, logger) {
   Debug::to_repr(self).output(logger)
 }

--- a/internal/qc_model/pkg.generated.mbti
+++ b/internal/qc_model/pkg.generated.mbti
@@ -23,7 +23,18 @@ pub fn SimpleDocument::contains_fractional_datetime(Self) -> Bool
 pub fn SimpleDocument::contains_negative_exponent_like_key(Self) -> Bool
 pub fn SimpleDocument::contains_string(Self) -> Bool
 pub fn SimpleDocument::contains_table(Self) -> Bool
+#deprecated
+pub fn SimpleDocument::equal(Self, Self) -> Bool
 pub fn SimpleDocument::from_toml(@toml.TomlValue) -> Self?
+#deprecated
+pub fn SimpleDocument::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn SimpleDocument::output(Self, &Logger) -> Unit
+#as_free_fn
+#deprecated
+pub fn SimpleDocument::to_repr(Self) -> @debug.Repr
+#deprecated
+pub fn SimpleDocument::to_string(Self) -> String
 pub fn SimpleDocument::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleDocument
 
@@ -39,7 +50,18 @@ pub(all) enum SimpleValue {
   SBooleanArray(Array[Bool])
   STable(Map[String, SimpleValue])
 } derive(Eq, @debug.Debug)
+#deprecated
+pub fn SimpleValue::equal(Self, Self) -> Bool
 pub fn SimpleValue::from_toml(@toml.TomlValue) -> Self?
+#deprecated
+pub fn SimpleValue::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn SimpleValue::output(Self, &Logger) -> Unit
+#as_free_fn
+#deprecated
+pub fn SimpleValue::to_repr(Self) -> @debug.Repr
+#deprecated
+pub fn SimpleValue::to_string(Self) -> String
 pub fn SimpleValue::to_toml(Self) -> @toml.TomlValue
 pub impl Show for SimpleValue
 

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -20,6 +20,13 @@ pub(all) struct Loc {
   end : @lexer.Position
 } derive(Eq, @debug.Debug)
 pub fn Loc::adjacent(Self, Self) -> Bool
+#deprecated
+pub fn Loc::equal(Self, Self) -> Bool
+#deprecated
+pub fn Loc::not_equal(Self, Self) -> Bool
+#as_free_fn
+#deprecated
+pub fn Loc::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Token {
   StringToken(String, loc~ : Loc, multiline~ : Bool)
@@ -38,7 +45,14 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, @debug.Debug)
+#deprecated
+pub fn Token::equal(Self, Self) -> Bool
 pub fn Token::loc(Self) -> Loc
+#deprecated
+pub fn Token::not_equal(Self, Self) -> Bool
+#as_free_fn
+#deprecated
+pub fn Token::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -12,6 +12,14 @@ pub(all) struct Loc {
 } derive(Eq, Debug)
 
 ///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend Loc with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend Loc with Debug::{to_repr}
+
+///|
 /// Token types for the lexer
 pub(all) enum Token {
   // Literals
@@ -37,6 +45,14 @@ pub(all) enum Token {
   Newline(loc~ : Loc)
   EOF(loc~ : Loc)
 } derive(Eq, Debug)
+
+///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend Token with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend Token with Debug::{to_repr}
 
 ///|
 /// Check if two locations are adjacent (end of first equals start of second).

--- a/moon.mod
+++ b/moon.mod
@@ -18,4 +18,4 @@ keywords = [ "toml", "parser", "config" ]
 
 description = "A TOML parser implementation in MoonBit"
 
-warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match-implicit_impl_as_method"
+warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match"

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -22,7 +22,16 @@ pub(all) enum TomlValue {
   TomlDateTime(@datetime.TomlDateTime)
 } derive(Eq, @debug.Debug)
 pub fn TomlValue::datetime_info(Self) -> (String, String)?
+#deprecated
+pub fn TomlValue::equal(Self, Self) -> Bool
 pub fn TomlValue::is_homogeneous_array(Array[Self]) -> Bool
+#deprecated
+pub fn TomlValue::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn TomlValue::output(Self, &Logger) -> Unit
+#as_free_fn
+#deprecated
+pub fn TomlValue::to_repr(Self) -> @debug.Repr
 pub fn TomlValue::to_string(Self) -> String
 pub fn TomlValue::type_name(Self) -> String
 pub fn TomlValue::validate(Self) -> Bool

--- a/toml.mbt
+++ b/toml.mbt
@@ -11,6 +11,14 @@ pub(all) enum TomlValue {
 } derive(Eq, Debug)
 
 ///|
+#deprecated("compare with `==`; the Eq impl is unaffected")
+pub extend TomlValue with Eq::{not_equal, equal}
+
+///|
+#deprecated("render via the Debug trait, e.g. `debug_inspect`")
+pub extend TomlValue with Debug::{to_repr}
+
+///|
 /// Re-export `TomlDateTime` so consumers see the type as `@toml.TomlDateTime`
 /// instead of having to import the `datetime` subpackage directly.
 pub using @datetime {type TomlDateTime}

--- a/toml_to_string.mbt
+++ b/toml_to_string.mbt
@@ -118,6 +118,10 @@ pub fn TomlValue::to_string(self : TomlValue) -> String {
 }
 
 ///|
+#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
+pub extend TomlValue with Show::{output}
+
+///|
 /// TODO: the logger interface is good?
 pub impl Show for TomlValue with fn output(self, logger) {
   logger.write_string(self.to_string())

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -50,6 +50,23 @@ priv suberror TableConflicts {
 } derive(Debug)
 
 ///|
+extend TableConflicts with Show::{to_string}
+
+///|
+/// Shadows the implicit promotion of `Show::output`; nothing calls it.
+#warnings("-unused_value")
+fn TableConflicts::output(self : TableConflicts, logger : &Logger) -> Unit {
+  Show::output(self, logger)
+}
+
+///|
+/// Shadows the implicit promotion of `Debug::to_repr`; nothing calls it.
+#warnings("-unused_value")
+fn TableConflicts::to_repr(self : TableConflicts) -> @debug.Repr {
+  Debug::to_repr(self)
+}
+
+///|
 /// Show impl for error messages
 impl Show for TableConflicts with fn output(self, logger) {
   match self {


### PR DESCRIPTION
## Summary

Part 2 of 2, following #105 (async bump + `ambiguous_braces`), now merged.

#105 silenced `implicit_impl_as_method` with a temporary `-implicit_impl_as_method` line in `moon.mod` so the async fix could land on its own. This PR fixes those 18 warnings properly and **removes that line**, restoring the full `+a` warning set.

The diff is **purely additive** — 140 insertions, and the single deletion is that temporary suppression line. No test assertions change.

(Supersedes #106, which GitHub auto-closed when #105's branch was deleted and refuses to reopen.)

## Which promotions are worth keeping?

Trait impls are still implicitly promoted to regular methods, which is deprecated and slated for removal. Once that lands, **only methods named in an `extend` declaration survive** — so each promotion is a decision: keep it, or let it go.

Rather than guess, I probed: mark every promotion `#deprecated` and read the resulting warnings. Exactly **one** is used anywhere:

| Promotion | Callers | Decision |
|---|---|---|
| `TomlDateTime::to_string` | 5 (datetime_extended_test.mbt) | **promoted for real** |
| `equal` / `not_equal` / `to_repr` / `output` (6 types, 17 total) | none | promoted `#deprecated` |

The 17 are trait plumbing, not API anyone should reach for as a method (`==` covers `Eq`; `to_repr`/`output` are `Debug`/`Show` internals). Cementing them into a published library's API permanently seemed wrong, so they're marked `#deprecated` and can be **deleted in a later release**.

Deprecating rather than dropping them outright gives downstream a warning window instead of a silent break — these methods are *already callable today* via the implicit promotion, so this doesn't add API, it just decides which parts have a future.

`TomlValue::to_string` is a hand-written method and is unaffected.

## `TableConflicts`

`TableConflicts` is `priv`, so its promoted methods are package-private: an `extend` declaring them is dead code (`unused_value`), while omitting it leaves the implicit promotion (`0079`). `#deprecated` doesn't rescue it either — a private promotion is unused whether or not it's deprecated.

The key point is that the warning is about the **promotion**, not the impls. So rather than delete `derive(Debug)` / `impl Show` (which would strip the error type of `Show`/`Debug` rendering and weaken two test assertions), this neutralizes just the promotion:

- keep `derive(Debug)` and `impl Show`
- `extend TableConflicts with Show::{to_string}` — the parser renders conflicts via `error.to_string()`
- shadow the two unused promotions with regular methods carrying `#warnings("-unused_value")`

The shims exist only to displace the implicit promotion and can be deleted once it's removed. The error type stays renderable through `Show`/`Debug`, stays private (absent from `.mbti`), and **every existing test assertion is untouched**.

## Verification

With `-implicit_impl_as_method` removed and the warning fully re-enabled:

- `moon check --deny-warn` — clean
- `moon fmt` / `moon info` — idempotent, no residual diff
- `moon test .` — 243/243 pass
- e2e — 397/397 pass
- `moon cram test --release tests/cram` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)