### PR TITLE
Migrate lexmatch to lexscan and share datetime regex

### DIFF
--- a/coverage_improvement_test.mbt
+++ b/coverage_improvement_test.mbt
@@ -107,7 +107,7 @@ test "test edge case number formats for error paths" {
   debug_inspect(
     tokens,
     content=(
-      #|Err(Failure("internal/tokenize/tokenize.mbt:972:12-972:41@bobzhang/toml FAILED: Invalid integer: 999999999999999999999999999999999999999"))
+      #|Err(Failure("internal/tokenize/tokenize.mbt:973:12-973:41@bobzhang/toml FAILED: Invalid integer: 999999999999999999999999999999999999999"))
     ),
   )
 }

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -650,15 +650,12 @@ fn @lexer.Lexer::read_binary_number(self : @lexer.Lexer) -> Int64 raise {
 /// Check if the current input matches a datetime pattern without consuming characters
 fn @lexer.Lexer::is_datetime_pattern(self : @lexer.Lexer) -> Bool {
   // Check for datetime patterns using regex
-  lexmatch self.view() with longest {
-    (
-      "[0-9]{2}:[0-9]{2}"
-      "(:[0-9]{2})?(\.[0-9]+)?",
-      // LocalTime pattern: HH:MM[:SS[.fff]] followed by valid terminator
-      rest
-    ) => check_datetime_terminator_string(rest)
+  lexscan self.view() with longest {
+    // LocalTime pattern: HH:MM[:SS[.fff]] followed by valid terminator
+    (START + re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?", after=rest) =>
+      check_datetime_terminator_string(rest)
     // LocalDate pattern: YYYY-MM-DD (always valid, may continue with T for datetime)
-    ("[0-9]{4}-[0-9]{2}-[0-9]{2}", _) => true
+    (START + re"[0-9]{4}-[0-9]{2}-[0-9]{2}", after=_) => true
     _ => false
   }
 }
@@ -683,9 +680,12 @@ fn @lexer.Lexer::read_datetime_with_loc(
   // - LocalTime: HH:MM:SS (starts with 2 digits, has colons)
   // - Date-based: YYYY-MM-DD (starts with 4 digits)
   //   - Check what follows T to determine: LocalDate, LocalDateTime, or OffsetDateTime
-  lexmatch self.view() with longest {
+  lexscan self.view() with longest {
     // LocalTime: HH:MM[:SS[.fff]] - must check first (2-digit start vs 4-digit)
-    (("[0-9]{2}:[0-9]{2}" "(:[0-9]{2})?(\.[0-9]+)?") as time, rest) => {
+    (
+      (START + re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?") as time,
+      after=rest,
+    ) => {
       self.update_view(rest)
       validate_time(time)
       let end_pos = self.get_loc()
@@ -695,7 +695,7 @@ fn @lexer.Lexer::read_datetime_with_loc(
       )
     }
     // Date-based patterns: lex YYYY-MM-DD first, then check continuation
-    ("[0-9]{4}-[0-9]{2}-[0-9]{2}" as date, rest) => {
+    ((START + re"[0-9]{4}-[0-9]{2}-[0-9]{2}") as date, after=rest) => {
       self.update_view(rest)
       validate_date(date)
       // Check for time component: T/t/space followed by HH:MM[:SS[.fff]]

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -9,6 +9,14 @@ pub fn default_loc() -> Loc {
 const START : Regex = re"^"
 
 ///|
+/// TOML date: `YYYY-MM-DD`.
+const DATE : Regex = re"[0-9]{4}-[0-9]{2}-[0-9]{2}"
+
+///|
+/// TOML time: `HH:MM` with optional `:SS` and `.fff` fraction.
+const TIME : Regex = re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?"
+
+///|
 /// Create a location from lexer positions
 fn make_loc(start_pos : @lexer.Position, end_pos : @lexer.Position) -> Loc {
   { start: start_pos, end: end_pos }
@@ -652,10 +660,9 @@ fn @lexer.Lexer::is_datetime_pattern(self : @lexer.Lexer) -> Bool {
   // Check for datetime patterns using regex
   lexscan self.view() with longest {
     // LocalTime pattern: HH:MM[:SS[.fff]] followed by valid terminator
-    (START + re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?", after=rest) =>
-      check_datetime_terminator_string(rest)
+    (START + TIME, after=rest) => check_datetime_terminator_string(rest)
     // LocalDate pattern: YYYY-MM-DD (always valid, may continue with T for datetime)
-    (START + re"[0-9]{4}-[0-9]{2}-[0-9]{2}", after=_) => true
+    (START + DATE, after=_) => true
     _ => false
   }
 }
@@ -682,10 +689,7 @@ fn @lexer.Lexer::read_datetime_with_loc(
   //   - Check what follows T to determine: LocalDate, LocalDateTime, or OffsetDateTime
   lexscan self.view() with longest {
     // LocalTime: HH:MM[:SS[.fff]] - must check first (2-digit start vs 4-digit)
-    (
-      (START + re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?") as time,
-      after=rest,
-    ) => {
+    ((START + TIME) as time, after=rest) => {
       self.update_view(rest)
       validate_time(time)
       let end_pos = self.get_loc()
@@ -695,14 +699,11 @@ fn @lexer.Lexer::read_datetime_with_loc(
       )
     }
     // Date-based patterns: lex YYYY-MM-DD first, then check continuation
-    ((START + re"[0-9]{4}-[0-9]{2}-[0-9]{2}") as date, after=rest) => {
+    ((START + DATE) as date, after=rest) => {
       self.update_view(rest)
       validate_date(date)
       // Check for time component: T/t/space followed by HH:MM[:SS[.fff]]
-      if self.view() =~ (
-          (re"^" + re"[Tt ][0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?") as time_with_t,
-          after=rest2,
-        ) {
+      if self.view() =~ ((START + re"[Tt ]" + TIME) as time_with_t, after=rest2) {
         self.update_view(rest2)
         // Validate time portion (skip the T/t/space separator) — view slice
         // avoids allocating a copy just for validation.

--- a/moon.mod
+++ b/moon.mod
@@ -18,4 +18,4 @@ keywords = [ "toml", "parser", "config" ]
 
 description = "A TOML parser implementation in MoonBit"
 
-warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning-lexmatch_longest_match"
+warnings = "+a-unused_optional_argument-unused_default_value-missing_invariant-missing_reasoning"


### PR DESCRIPTION
## Summary

Two related commits on the datetime lexer:

1. **Migrate `lexmatch` → `lexscan`** — `lexmatch ... with longest` is deprecated (warning `0077`); `moon.mod` was silencing it with `-lexmatch_longest_match`, masking a pending migration. Both sites converted, suppression removed.
2. **Share the datetime regex** — the migration left the same subpatterns duplicated; factor them into named consts.

## 1. lexscan migration

Per the [official guide](https://www.moonbitlang.com/updates/):

| Old (`lexmatch`) | New (`lexscan`) |
|---|---|
| string patterns `"[0-9]{2}..."` | regex literals `re"..."` |
| adjacent juxtaposition `"a" "b"` | `+` concatenation |
| trailing rest binder `, rest` / `, _` | `after=rest` / `after=_` |
| `as` captures | preserved on the parenthesized regex |

## 2. Shared regex consts

The migration surfaced real duplication — `YYYY-MM-DD` appeared twice, `HH:MM[:SS[.fff]]` three times. Because `lexscan`/`=~` patterns compose regex consts with `+`, these factor cleanly beside the existing `START` anchor:

```moonbit
const DATE : Regex = re"[0-9]{4}-[0-9]{2}-[0-9]{2}"
const TIME : Regex = re"[0-9]{2}:[0-9]{2}" + re"(:[0-9]{2})?(\.[0-9]+)?"
```

The pattern sites become their intent:

```moonbit
(START + TIME, after=rest) => ...          // was START + re"[0-9]{2}:[0-9]{2}" + re"(:...)?..."
(START + DATE, after=_) => true            // was START + re"[0-9]{4}-[0-9]{2}-[0-9]{2}"
(START + re"[Tt ]" + TIME) as time_with_t  // T-separated time reuses TIME
```

The `[Tt ]`-prefixed case is the nice one: `re"[Tt ]" + TIME` is byte-identical to the old `re"[Tt ][0-9]{2}:[0-9]{2}" + re"(:...)?..."`, but now obviously "a separator then a time".

## Behavior-preserving

Both commits are pure rewrites — the composed regexes are byte-identical to the originals. The only test delta was a **source line number** in an unrelated "Invalid integer" error snapshot (`coverage_improvement_test.mbt`), shifted by the added const lines.

Left the 7 inline `re"^"` sites in the pre-existing `=~` blocks (hex/oct/bin lexers) untouched — out of scope; could become `START` in a later sweep.

## Verification

- `moon check --deny-warn` — clean, **with `-lexmatch_longest_match` removed**
- `moon test .` — 243/243 pass
- e2e (incl. official TOML datetime suite) — 397/397 pass
- `moon cram test --release tests/cram` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)