### PR TITLE
ci: run the whole workspace, not just the root package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           moon info
           git diff --exit-code
       
-      - name: moon test (unit tests)
-        run: moon test .
+      - name: moon test (whole workspace)
+        run: moon test
 
       - name: moon cram (native CLI)
         if: matrix.channel == 'nightly'


### PR DESCRIPTION
## Summary

CI ran `moon test .` — only the root package: **243 tests**. The workspace has **397**. Dropping the `.` makes CI run all of them.

CI on this PR confirms: `Total tests: 397, passed: 397, failed: 0.`

## What this gates

| Newly run in CI | Tests | Gates? |
|---|---|---|
| `internal/tokenize` | **123** — the tokenizer, the most intricate code here | ✅ |
| `internal/qc_model` | 1 quickcheck property = **2,000 generated round-trip cases** | ✅ |
| `e2e/known_failures_test.mbt` | 16 regression tests | ✅ |
| `e2e/e2e_test.mbt` (official toml-test suite) | 2 | ❌ — **not run at all; see below** |

Verified the e2e module is genuinely reached by planting a failing canary in `known_failures_test.mbt`: `moon test` reports it, `moon test .` does not. (Reverted.)

## The conformance suite is separately broken (pre-existing, not touched here)

While reviewing, I found `e2e/e2e_test.mbt` (the official toml-test suite) is broken three independent ways. **None of this is changed by this PR** — flagging it because it means "397/397" must not be read as "conformance is green":

1. **Not run on the default target.** Default is `wasm-gc`; the two suite tests are `async` + `@fs`, so they're excluded. `moon test` = 397, `moon test --target native` = 399. CI never executes them.
2. **Broken on native.** With `--target native` they fail: `IOError(No such file or directory)` — `collect_toml_files("e2e/testdata/valid", ...)` is a relative path that doesn't resolve from the test CWD. This reproduces even with the command the e2e README documents (`moon test e2e --target native`).
3. **Wouldn't assert even if it ran.** The suite counts failures, `println`s a summary, writes `_valid_failures.txt`, and ends — no `fail()`. I confirmed by corrupting a `testdata/valid` fixture to a guaranteed mismatch: still 397/397 green.

`e2e/README.mbt.md` reports 262/262 valid and 474/483 invalid (98.8%). That status is stale — the suite does not currently run.

## Risks checked

- **Local vs registry linkage** — `e2e/moon.mod` pins `bobzhang/toml@0.4.0`, root is `0.4.1`. `moon tree` shows `bobzhang/toml -> bobzhang/toml@0.4.1 (local ...) [workspace member]`: the workspace member wins and the pin is ignored. e2e tests the working tree. Pin is inert but stale.
- **Target** — this PR keeps the default (`wasm-gc`), which is what CI already used. No target change, no new failures.
- **Cost** — ~1.7s locally; CI stable job 20s.

## Follow-up (deliberately not bundled)

- Repair the conformance suite: resolve fixtures robustly (not CWD-relative), run it on native, add `fail()` on failures plus a non-empty-corpus assert, and triage the 9 documented TOML 1.0-vs-1.1 known failures into an explicit allowlist.
- **Test dedup is on hold.** The plan to delete the root's ~1,057 hand-transcribed official-suite lines assumed e2e covered that ground. It does not. Those tests are currently the *only* conformance enforcement and must not be deleted until the e2e suite actually works.

Reviewed with `codex exec`, which independently identified the missing assertions and confirmed the workspace-member resolution via `moon tree`.

## Verification

- CI (stable): `moon test` -> 397/397
- Local: clean rebuild, `MOONBIT_NEW_NATIVE` unset -> 397/397

🤖 Generated with [Claude Code](https://claude.com/claude-code)