### PR TITLE
fix(e2e): make the toml-test conformance suite actually enforce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       - name: moon test (whole workspace)
         run: moon test
 
+      # The official toml-test conformance suite is async + uses @fs, so it is
+      # excluded from the default wasm-gc target and only runs on native.
+      - name: moon test e2e (toml-test conformance, native)
+        run: moon test e2e --target native
+
       - name: moon cram (native CLI)
         if: matrix.channel == 'nightly'
         run: moon cram test --release tests/cram

--- a/e2e/README.mbt.md
+++ b/e2e/README.mbt.md
@@ -29,6 +29,12 @@ The `--target native` flag is required because the tests use filesystem APIs (`@
 
 ## Known TOML 1.0 vs 1.1 Differences (9 expected failures)
 
+These are pinned in `known_toml11_diffs` in `e2e_test.mbt` and enforced as an
+exact set: a fixture that starts being accepted is reported as `[REGRESSION]`,
+and one that starts being rejected correctly is reported as
+`[STALE-EXEMPTION]` so the list cannot silently rot. Keep this table and that
+list in sync.
+
 The parser targets **TOML 1.1**. These 9 invalid-test "failures" are TOML 1.0 restrictions
 that TOML 1.1 intentionally relaxes — the parser is correct:
 

--- a/e2e/e2e_test.mbt
+++ b/e2e/e2e_test.mbt
@@ -1,7 +1,7 @@
 ///|
 async test "valid toml-test suite" {
   let files : Array[String] = []
-  @e2e.collect_toml_files("e2e/testdata/valid", files)
+  @e2e.collect_toml_files("testdata/valid", files)
   files.sort()
   let mut passed = 0
   let mut failed = 0
@@ -46,46 +46,74 @@ async test "valid toml-test suite" {
   println(
     "\{passed} passed, \{failed} failed out of \{passed + failed} valid tests",
   )
+  guard passed + failed > 0 else {
+    fail(
+      "valid corpus is empty — no .toml/.json pairs found under testdata/valid",
+    )
+  }
   if failed > 0 {
     let msg = StringBuilder()
     msg <+ "\{failed} of \{passed + failed} valid tests failed:\n"
     for f in failures {
       msg <+ "  \{f}\n"
     }
-    let msg = msg.to_string()
-    println(msg)
-    @fs.write_string_to_file("e2e/_valid_failures.txt", msg)
+    fail("valid toml-test suite:\n\{msg}")
   }
 }
 
 ///|
+/// Invalid-suite fixtures this parser intentionally accepts.
+///
+/// The corpus encodes TOML 1.0 restrictions; this parser targets TOML 1.1,
+/// which relaxes them, so accepting these inputs is correct behaviour rather
+/// than a conformance bug.
+///
+/// The suite compares the failing set against this list *exactly*: a new
+/// failure is a regression, and an entry that stops failing is a stale
+/// exemption. Both fail the test, so the list cannot silently rot.
+let known_toml11_diffs : Array[String] = [
+  // Seconds are optional in a time.
+  "testdata/invalid/datetime/no-secs.toml", "testdata/invalid/local-datetime/no-secs.toml",
+  "testdata/invalid/local-time/no-secs.toml",
+  // Newlines are allowed inside inline tables.
+   "testdata/invalid/inline-table/linebreak-01.toml", "testdata/invalid/inline-table/linebreak-02.toml",
+  "testdata/invalid/inline-table/linebreak-03.toml", "testdata/invalid/inline-table/linebreak-04.toml",
+  // A trailing comma is allowed in an inline table.
+   "testdata/invalid/inline-table/trailing-comma.toml",
+  // `\xHH` hex escapes are allowed.
+   "testdata/invalid/string/basic-byte-escapes.toml",
+]
+
+///|
 async test "invalid toml-test suite" {
   let files : Array[String] = []
-  @e2e.collect_toml_files("e2e/testdata/invalid", files)
+  @e2e.collect_toml_files("testdata/invalid", files)
   files.sort()
+  guard files.length() > 0 else {
+    fail("invalid corpus is empty — testdata/invalid did not resolve")
+  }
   let mut passed = 0
-  let mut failed = 0
-  let failures : Array[String] = []
+  let accepted : Array[String] = []
   for toml_path in files {
     match @e2e.run_single_invalid_test(toml_path) {
       None => passed += 1
-      Some(msg) => {
-        failures.push(msg)
-        failed += 1
-      }
+      Some(_) => accepted.push(toml_path)
     }
   }
   println(
-    "\{passed} passed, \{failed} failed out of \{passed + failed} invalid tests",
+    "\{passed} passed, \{accepted.length()} failed out of \{files.length()} invalid tests",
   )
-  if failed > 0 {
+  let regressions = accepted.filter(p => !known_toml11_diffs.contains(p))
+  let stale = known_toml11_diffs.filter(p => !accepted.contains(p))
+  if regressions.length() > 0 || stale.length() > 0 {
     let msg = StringBuilder()
-    msg <+ "\{failed} of \{passed + failed} invalid tests failed:\n"
-    for f in failures {
-      msg <+ "  \{f}\n"
+    for p in regressions {
+      msg <+ "  [REGRESSION] accepted an invalid document: \{p}\n"
     }
-    let msg = msg.to_string()
-    println(msg)
-    @fs.write_string_to_file("e2e/_invalid_failures.txt", msg)
+    for p in stale {
+      msg <+
+        "  [STALE-EXEMPTION] now rejected correctly, drop from known_toml11_diffs: \{p}\n"
+    }
+    fail("invalid toml-test suite:\n\{msg}")
   }
 }


### PR DESCRIPTION
## Summary

The official toml-test conformance suite has **never been gating anything**. `e2e/README.mbt.md` reports 262/262 valid and 474/483 invalid (98.8%) — that status was accurate once, but the suite has been dead. It was broken three independent ways:

1. **Wrong CWD.** Fixture paths were `"e2e/testdata/valid"`, but the test process runs with the **e2e module directory** as its CWD, so the walk raised `IOError(No such file or directory)`. This reproduced even with the command the README documents (`moon test e2e --target native`).
2. **Never executed by CI.** The suite is `async` and uses `@fs`, so it's excluded from the default `wasm-gc` target. `moon test` = 397 tests; `moon test --target native` = 399. The two suite tests were never in the run.
3. **Never asserted.** It counted failures, printed a summary, wrote `_valid_failures.txt`, and ended — no `fail()`. Corrupting a fixture to a guaranteed mismatch still produced a green run.

## The fix

- **Paths** -> `"testdata/valid"` / `"testdata/invalid"`. The suite now runs, producing exactly the numbers the README has been claiming: **262/262 valid, 474/483 invalid**.
- **Valid suite** fails on any mismatch. Both suites fail if the corpus is empty, so a future path break can't pass vacuously.
- **Invalid suite** compares the accepted-but-should-reject set *exactly* against `known_toml11_diffs`. Those 9 fixtures encode TOML 1.0 restrictions that TOML 1.1 relaxes (optional seconds; newlines and trailing commas in inline tables; `\xHH` escapes) — this parser targets 1.1, so accepting them is correct, not a bug. A new failure reports `[REGRESSION]`; an entry that stops failing reports `[STALE-EXEMPTION]`, so the allowlist cannot silently rot.
- **ci.yml** gains `moon test e2e --target native`, since the default workspace run cannot see these tests.

## Verified the guards fire — not just that it passes

The old suite passed too, so "it's green" proves nothing. Each guard was checked by deliberately breaking something:

| Injected fault | Result |
|---|---|
| Corrupt a `testdata/valid` fixture | ✅ fails — `[MISMATCH] testdata/valid/empty-crlf.toml` (**this was green before**) |
| Drop an entry from the allowlist | ✅ fails — `[REGRESSION] accepted an invalid document: .../datetime/no-secs.toml` |
| Add a bogus allowlist entry | ✅ fails — `[STALE-EXEMPTION] ... drop from known_toml11_diffs` |
| Point the walk at an empty directory | ✅ fails — `valid corpus is empty` |

Restored, the suite is green.

## Note

Pre-existing gap left alone: `run_single_invalid_test` returns "pass" for non-UTF-8 fixtures *assuming* the parser would reject them, without testing it. Out of scope here.

This also unblocks the test-dedup work: the root's ~1,057 hand-transcribed official-suite lines were the only conformance enforcement while e2e was dead. With e2e actually enforcing, that duplication can finally be assessed on its merits.

## Verification

- `moon check --deny-warn` — clean
- `moon test` — 397/397
- `moon test e2e --target native` — 15/15 (262 valid + 474 invalid cases)
- `moon cram test --release tests/cram` — 6/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)