### PR TITLE
fix(parser): number-like bare keys, table redefinition, int64 overflow

### DIFF
--- a/coverage_improvement_test.mbt
+++ b/coverage_improvement_test.mbt
@@ -107,7 +107,21 @@ test "test edge case number formats for error paths" {
   debug_inspect(
     tokens,
     content=(
-      #|Err(Failure("internal/tokenize/tokenize.mbt:987:12-987:41@bobzhang/toml FAILED: Invalid integer: 999999999999999999999999999999999999999"))
+      #|Ok(
+      #|  [
+      #|    Identifier(
+      #|      "huge",
+      #|      loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 5 } },
+      #|    ),
+      #|    Equals(loc={ start: { line: 1, column: 6 }, end: { line: 1, column: 7 } }),
+      #|    IntegerToken(
+      #|      9223372036854775807,
+      #|      loc={ start: { line: 1, column: 8 }, end: { line: 1, column: 47 } },
+      #|      raw="999999999999999999999999999999999999999",
+      #|    ),
+      #|    EOF(loc={ start: { line: 1, column: 47 }, end: { line: 1, column: 47 } }),
+      #|  ],
+      #|)
     ),
   )
 }

--- a/coverage_improvement_test.mbt
+++ b/coverage_improvement_test.mbt
@@ -107,7 +107,7 @@ test "test edge case number formats for error paths" {
   debug_inspect(
     tokens,
     content=(
-      #|Err(Failure("internal/tokenize/tokenize.mbt:973:12-973:41@bobzhang/toml FAILED: Invalid integer: 999999999999999999999999999999999999999"))
+      #|Err(Failure("internal/tokenize/tokenize.mbt:987:12-987:41@bobzhang/toml FAILED: Invalid integer: 999999999999999999999999999999999999999"))
     ),
   )
 }
@@ -209,6 +209,7 @@ test "test mixed case hex digits" {
       #|  IntegerToken(
       #|    11259375,
       #|    loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 21 } },
+      #|    raw="0xaBcDeF",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 21 }, end: { line: 1, column: 21 } }),
       #|]

--- a/e2e/known_failures_test.mbt
+++ b/e2e/known_failures_test.mbt
@@ -30,7 +30,7 @@ test "fixed: leading underscore value rejected (not infinite loop)" {
   debug_inspect(
     result,
     content=(
-      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 5 }, end: { line: 1, column: 7 } }"))
+      #|Err(Failure("parser.mbt:219:20-219:70@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 5 }, end: { line: 1, column: 7 } }"))
     ),
   )
 }

--- a/e2e/known_failures_test.mbt
+++ b/e2e/known_failures_test.mbt
@@ -30,7 +30,7 @@ test "fixed: leading underscore value rejected (not infinite loop)" {
   debug_inspect(
     result,
     content=(
-      #|Err(Failure("parser.mbt:194:20-194:70@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 5 }, end: { line: 1, column: 7 } }"))
+      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Expected value at { start: { line: 1, column: 5 }, end: { line: 1, column: 7 } }"))
     ),
   )
 }

--- a/internal/tokenize/datetime_lexer_test.mbt
+++ b/internal/tokenize/datetime_lexer_test.mbt
@@ -814,6 +814,7 @@ test "lexer datetime disambiguation" {
       #|  IntegerToken(
       #|    123,
       #|    loc={ start: { line: 2, column: 9 }, end: { line: 2, column: 12 } },
+      #|    raw="123",
       #|  ),
       #|  EOF(loc={ start: { line: 2, column: 12 }, end: { line: 2, column: 12 } }),
       #|]

--- a/internal/tokenize/lexer_bug_test.mbt
+++ b/internal/tokenize/lexer_bug_test.mbt
@@ -30,6 +30,7 @@ test "test invalid float parsing" {
       #|    IntegerToken(
       #|      3,
       #|      loc={ start: { line: 1, column: 15 }, end: { line: 1, column: 16 } },
+      #|      raw="3",
       #|    ),
       #|    EOF(loc={ start: { line: 1, column: 16 }, end: { line: 1, column: 16 } }),
       #|  ],
@@ -234,6 +235,7 @@ test "test hex with valid delimiters" {
       #|  IntegerToken(
       #|    4666,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 13 } },
+      #|    raw="0x123A",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 13 } }),
       #|]
@@ -257,11 +259,13 @@ test "test hex with valid delimiters" {
       #|  IntegerToken(
       #|    4666,
       #|    loc={ start: { line: 1, column: 8 }, end: { line: 1, column: 14 } },
+      #|    raw="0x123A",
       #|  ),
       #|  Comma(loc={ start: { line: 1, column: 14 }, end: { line: 1, column: 15 } }),
       #|  IntegerToken(
       #|    11,
       #|    loc={ start: { line: 1, column: 16 }, end: { line: 1, column: 19 } },
+      #|    raw="0xB",
       #|  ),
       #|  RightBracket(loc={ start: { line: 1, column: 19 }, end: { line: 1, column: 20 } }),
       #|  EOF(loc={ start: { line: 1, column: 20 }, end: { line: 1, column: 20 } }),
@@ -289,6 +293,7 @@ test "test hex case variations" {
       #|  IntegerToken(
       #|    11259375,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 15 } },
+      #|    raw="0xaBcDeF",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 15 }, end: { line: 1, column: 15 } }),
       #|]
@@ -336,6 +341,7 @@ test "test octal with valid delimiters" {
       #|  IntegerToken(
       #|    493,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 12 } },
+      #|    raw="0o755",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 12 }, end: { line: 1, column: 12 } }),
       #|]
@@ -359,11 +365,13 @@ test "test octal with valid delimiters" {
       #|  IntegerToken(
       #|    420,
       #|    loc={ start: { line: 1, column: 8 }, end: { line: 1, column: 13 } },
+      #|    raw="0o644",
       #|  ),
       #|  Comma(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 14 } }),
       #|  IntegerToken(
       #|    493,
       #|    loc={ start: { line: 1, column: 15 }, end: { line: 1, column: 20 } },
+      #|    raw="0o755",
       #|  ),
       #|  RightBracket(loc={ start: { line: 1, column: 20 }, end: { line: 1, column: 21 } }),
       #|  EOF(loc={ start: { line: 1, column: 21 }, end: { line: 1, column: 21 } }),
@@ -412,6 +420,7 @@ test "test binary with valid delimiters" {
       #|  IntegerToken(
       #|    10,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 13 } },
+      #|    raw="0b1010",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 13 } }),
       #|]
@@ -435,11 +444,13 @@ test "test binary with valid delimiters" {
       #|  IntegerToken(
       #|    5,
       #|    loc={ start: { line: 1, column: 8 }, end: { line: 1, column: 13 } },
+      #|    raw="0b101",
       #|  ),
       #|  Comma(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 14 } }),
       #|  IntegerToken(
       #|    6,
       #|    loc={ start: { line: 1, column: 15 }, end: { line: 1, column: 20 } },
+      #|    raw="0b110",
       #|  ),
       #|  RightBracket(loc={ start: { line: 1, column: 20 }, end: { line: 1, column: 21 } }),
       #|  EOF(loc={ start: { line: 1, column: 21 }, end: { line: 1, column: 21 } }),

--- a/internal/tokenize/lexer_test.mbt
+++ b/internal/tokenize/lexer_test.mbt
@@ -1631,7 +1631,7 @@ test "test hex overflow edge case" {
       value => Ok(value)
     },
     content=(
-      #|Err(Failure("internal/tokenize/tokenize.mbt:551:7-551:71@bobzhang/toml FAILED: Invalid hex number: value out of Int64 range at line 1, column 7"))
+      #|Err(Failure("internal/tokenize/tokenize.mbt:555:7-555:71@bobzhang/toml FAILED: Invalid hex number: value out of Int64 range at line 1, column 7"))
     ),
   )
 }

--- a/internal/tokenize/lexer_test.mbt
+++ b/internal/tokenize/lexer_test.mbt
@@ -45,6 +45,7 @@ test "tokenize integer" {
       #|  IntegerToken(
       #|    42,
       #|    loc={ start: { line: 1, column: 10 }, end: { line: 1, column: 12 } },
+      #|    raw="42",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 12 }, end: { line: 1, column: 12 } }),
       #|]
@@ -120,16 +121,19 @@ test "tokenize array syntax" {
       #|  IntegerToken(
       #|    1,
       #|    loc={ start: { line: 1, column: 2 }, end: { line: 1, column: 3 } },
+      #|    raw="1",
       #|  ),
       #|  Comma(loc={ start: { line: 1, column: 3 }, end: { line: 1, column: 4 } }),
       #|  IntegerToken(
       #|    2,
       #|    loc={ start: { line: 1, column: 5 }, end: { line: 1, column: 6 } },
+      #|    raw="2",
       #|  ),
       #|  Comma(loc={ start: { line: 1, column: 6 }, end: { line: 1, column: 7 } }),
       #|  IntegerToken(
       #|    3,
       #|    loc={ start: { line: 1, column: 8 }, end: { line: 1, column: 9 } },
+      #|    raw="3",
       #|  ),
       #|  RightBracket(loc={ start: { line: 1, column: 9 }, end: { line: 1, column: 10 } }),
       #|  EOF(loc={ start: { line: 1, column: 10 }, end: { line: 1, column: 10 } }),
@@ -196,6 +200,7 @@ test "tokenize multiline" {
       #|  IntegerToken(
       #|    42,
       #|    loc={ start: { line: 2, column: 8 }, end: { line: 2, column: 10 } },
+      #|    raw="42",
       #|  ),
       #|  EOF(loc={ start: { line: 2, column: 10 }, end: { line: 2, column: 10 } }),
       #|]
@@ -335,6 +340,7 @@ test "tokenize hexadecimal numbers" {
       #|  IntegerToken(
       #|    57005,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 13 } },
+      #|    raw="0xDEAD",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 13 } }),
       #|]
@@ -383,6 +389,7 @@ test "tokenize octal numbers" {
       #|  IntegerToken(
       #|    493,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 12 } },
+      #|    raw="0o755",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 12 }, end: { line: 1, column: 12 } }),
       #|]
@@ -431,6 +438,7 @@ test "tokenize binary numbers" {
       #|  IntegerToken(
       #|    13,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 13 } },
+      #|    raw="0b1101",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 13 } }),
       #|]
@@ -479,6 +487,7 @@ test "tokenize numbers with underscores" {
       #|  IntegerToken(
       #|    1000000,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 16 } },
+      #|    raw="1_000_000",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 16 }, end: { line: 1, column: 16 } }),
       #|]
@@ -524,6 +533,7 @@ test "tokenize numbers with underscores" {
       #|  IntegerToken(
       #|    65535,
       #|    loc={ start: { line: 1, column: 13 }, end: { line: 1, column: 20 } },
+      #|    raw="0xFF_FF",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 20 }, end: { line: 1, column: 20 } }),
       #|]
@@ -550,6 +560,7 @@ test "tokenize special hex digits" {
       #|  IntegerToken(
       #|    81985529216486895,
       #|    loc={ start: { line: 1, column: 14 }, end: { line: 1, column: 32 } },
+      #|    raw="0x0123456789ABCDEF",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 32 }, end: { line: 1, column: 32 } }),
       #|]
@@ -691,6 +702,7 @@ test "test binary number with underscores" {
       #|  IntegerToken(
       #|    172,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 18 } },
+      #|    raw="0b1010_1100",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 18 }, end: { line: 1, column: 18 } }),
       #|]
@@ -1542,6 +1554,7 @@ test "hex number with underscores" {
       #|  IntegerToken(
       #|    3735928559,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 20 } },
+      #|    raw="0xDE_AD_BE_EF",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 20 }, end: { line: 1, column: 20 } }),
       #|]
@@ -1602,29 +1615,23 @@ test "very large invalid float" {
 }
 
 ///|
-/// Test edge case for hex digit error handling  
+/// Hex numbers that exceed the Int64 range are rejected (used to silently
+/// wrap around, e.g. 0xFFFFFFFFFFFFFFFF parsed as -1).
 test "test hex overflow edge case" {
-  // Test a hex number that might cause overflow issues
-  let tokens = @tokenize.tokenize(
-    (
-      #|hex = 0xFFFFFFFFFFFFFFFF
-    ),
-  )
   debug_inspect(
-    tokens,
+    try
+      @tokenize.tokenize(
+        (
+          #|hex = 0xFFFFFFFFFFFFFFFF
+        ),
+      )
+    catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
-      #|[
-      #|  Identifier(
-      #|    "hex",
-      #|    loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 4 } },
-      #|  ),
-      #|  Equals(loc={ start: { line: 1, column: 5 }, end: { line: 1, column: 6 } }),
-      #|  IntegerToken(
-      #|    -1,
-      #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 25 } },
-      #|  ),
-      #|  EOF(loc={ start: { line: 1, column: 25 }, end: { line: 1, column: 25 } }),
-      #|]
+      #|Err(Failure("internal/tokenize/tokenize.mbt:551:7-551:71@bobzhang/toml FAILED: Invalid hex number: value out of Int64 range at line 1, column 7"))
     ),
   )
 }
@@ -1725,6 +1732,7 @@ test "attempt hex digit error path" {
       #|  IntegerToken(
       #|    188900967593046,
       #|    loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 21 } },
+      #|    raw="0xABCDEF123456",
       #|  ),
       #|  EOF(loc={ start: { line: 1, column: 21 }, end: { line: 1, column: 21 } }),
       #|]

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -12,6 +12,10 @@ pub fn default_loc() -> Loc
 
 pub fn tokenize(String) -> Array[Token] raise
 
+pub fn validate_float_literal(String) -> Unit raise
+
+pub fn validate_integer_literal(String) -> Unit raise
+
 // Errors
 
 // Types and methods

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -29,7 +29,7 @@ pub fn Loc::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Token {
   StringToken(String, loc~ : Loc, multiline~ : Bool)
-  IntegerToken(Int64, loc~ : Loc)
+  IntegerToken(Int64, loc~ : Loc, raw~ : String)
   FloatToken(Double, loc~ : Loc, raw~ : String)
   BooleanToken(Bool, loc~ : Loc)
   DateTimeToken(@datetime.TomlDateTime, loc~ : Loc)

--- a/internal/tokenize/token.mbt
+++ b/internal/tokenize/token.mbt
@@ -24,7 +24,7 @@ pub extend Loc with Debug::{to_repr}
 pub(all) enum Token {
   // Literals
   StringToken(String, loc~ : Loc, multiline~ : Bool)
-  IntegerToken(Int64, loc~ : Loc)
+  IntegerToken(Int64, loc~ : Loc, raw~ : String)
   FloatToken(Double, loc~ : Loc, raw~ : String)
   BooleanToken(Bool, loc~ : Loc)
   DateTimeToken(@datetime.TomlDateTime, loc~ : Loc)
@@ -69,7 +69,7 @@ pub fn Loc::adjacent(self : Loc, other : Loc) -> Bool {
 pub fn Token::loc(self : Self) -> Loc {
   match self {
     StringToken(_, loc~, ..) => loc
-    IntegerToken(_, loc~) => loc
+    IntegerToken(_, loc~, ..) => loc
     FloatToken(_, loc~, ..) => loc
     BooleanToken(_, loc~) => loc
     DateTimeToken(_, loc~) => loc

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -520,6 +520,10 @@ fn @lexer.Lexer::read_multiline_literal_string(
 const INT64_MAX = 9223372036854775807L
 
 ///|
+/// Smallest value a TOML integer can take (signed 64-bit).
+const INT64_MIN : Int64 = -9223372036854775807L - 1L
+
+///|
 /// Parse hexadecimal number. Returns the value and the raw source text
 /// (prefix + digits, underscores preserved) so the parser can still use the
 /// token as a bare key.
@@ -960,15 +964,11 @@ fn @lexer.Lexer::read_number_with_loc(
   }
   let s = sb.to_string()
   let raw_s = raw.to_string()
-  if is_float {
-    validate_float_string(s, raw_s) catch {
-      e => fail(self.error(e.to_string()))
-    }
-  } else {
-    validate_integer_string(raw_s) catch {
-      e => fail(self.error(e.to_string()))
-    }
-  }
+  // Numeric validation (underscore placement, dot placement, Int64 range)
+  // is NOT done here: the text may be a bare key, where TOML applies no
+  // numeric rules at all. The parser validates the raw text when — and only
+  // when — the token is consumed as a value (see validate_integer_literal /
+  // validate_float_literal).
   let end_pos = self.get_loc()
   let loc = make_loc(start_pos, end_pos)
   if is_float {
@@ -983,10 +983,59 @@ fn @lexer.Lexer::read_number_with_loc(
       raw=raw_s,
     )
   } else {
-    IntegerToken(@string.parse_int64(s), loc~, raw=raw_s) catch {
-      _ => fail("Invalid integer: \{s}")
+    // Saturate on Int64 overflow so the token always carries a value; the
+    // parser never observes it because it range-checks the raw text first.
+    IntegerToken(
+      @string.parse_int64(s) catch {
+        _ => if s is ['-', ..] { INT64_MIN } else { INT64_MAX }
+      },
+      loc~,
+      raw=raw_s,
+    )
+  }
+}
+
+///|
+/// Remove underscores from a numeric literal's raw text.
+fn strip_underscores(raw : String) -> String {
+  let sb = StringBuilder()
+  for ch in raw {
+    if ch != '_' {
+      sb.write_char(ch)
     }
   }
+  sb.to_string()
+}
+
+///|
+/// Validate a decimal integer literal from its raw source text (optional
+/// sign, underscores preserved): underscore placement and Int64 range.
+///
+/// The tokenizer emits decimal numeric tokens without validating them
+/// because the same text can be a bare key, where TOML applies no numeric
+/// rules. The parser calls this when — and only when — the token is used
+/// as a value. Radix-prefixed literals (0x/0o/0b) are not covered: they
+/// can never be confused with values here since the tokenizer already
+/// validated them (digits, underscores, and Int64 range) at lex time.
+pub fn validate_integer_literal(raw : String) -> Unit raise {
+  if raw.has_prefix("0x") || raw.has_prefix("0o") || raw.has_prefix("0b") {
+    return
+  }
+  validate_underscores(raw)
+  let s = strip_underscores(raw)
+  let _ = @string.parse_int64(s) catch {
+    _ => raise Failure::Failure("Invalid integer: \{s}")
+  }
+}
+
+///|
+/// Validate a decimal float literal from its raw source text (optional
+/// sign, underscores preserved): underscore placement and dot placement.
+///
+/// See validate_integer_literal for why validation is deferred to the
+/// parser.
+pub fn validate_float_literal(raw : String) -> Unit raise {
+  validate_float_string(strip_underscores(raw), raw)
 }
 
 ///|
@@ -1006,12 +1055,6 @@ fn validate_float_string(s : String, raw : String) -> Unit raise {
     }
   }
   // Validate underscore placement in raw string
-  validate_underscores(raw)
-}
-
-///|
-/// Validate a decimal integer string for underscore placement.
-fn validate_integer_string(raw : String) -> Unit raise {
   validate_underscores(raw)
 }
 

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -516,23 +516,29 @@ fn @lexer.Lexer::read_multiline_literal_string(
 }
 
 ///|
-/// Parse hexadecimal number
-fn @lexer.Lexer::read_hex_number(self : @lexer.Lexer) -> Int64 raise {
+/// Largest value a TOML integer can take (signed 64-bit).
+const INT64_MAX = 9223372036854775807L
+
+///|
+/// Parse hexadecimal number. Returns the value and the raw source text
+/// (prefix + digits, underscores preserved) so the parser can still use the
+/// token as a bare key.
+fn @lexer.Lexer::read_hex_number(self : @lexer.Lexer) -> (Int64, String) raise {
 
   // (?:[0-9a-fA-F][0-9a-fA-F]*)(?:_[0-9a-fA-F][0-9a-fA-F]*)*
   // TODO(upstream): support non capturing group
   let mut result = 0L
   // 0xA__FF_12 is invalid according to spec
   guard self.view() =~ (
-    re"^" +
-    re"0[xX]" +
-    (re"[0-9a-fA-F]+(_[0-9a-fA-F]+)*" as hex_digits),
+    (re"^" + re"0x" + re"[0-9a-fA-F]+(_[0-9a-fA-F]+)*") as raw,
     after=rest,
   ) else {
     fail(self.error("Invalid hex number format"))
   }
-  for ch in hex_digits {
-    if ch is '_' {
+  let mut i = 0
+  for ch in raw {
+    i = i + 1
+    if i <= 2 || ch is '_' { // skip the "0x" prefix and underscores
       continue
     }
     let digit_value = match ch {
@@ -541,16 +547,22 @@ fn @lexer.Lexer::read_hex_number(self : @lexer.Lexer) -> Int64 raise {
       'A'..='F' => (ch.to_int() - 'A'.to_int()).to_int64() + 10L
       _ => fail(self.error("Invalid hex digit"))
     }
+    if result > (INT64_MAX - digit_value) / 16L {
+      fail(self.error("Invalid hex number: value out of Int64 range"))
+    }
     result = result * 16L + digit_value
   }
   self.update_view(rest)
 
   // 0-width assertion
   match self.view() {
-    [] => result
+    [] => (result, raw.to_owned())
+    // A '.' means a dotted bare key like `0xAB.cd`; the parser splits the
+    // raw text, so this is not an error here.
+    ['.', ..] => (result, raw.to_owned())
     [delimited, ..] =>
       if delimited is (' ' | '\t' | '\r' | '\n' | ',' | ']' | '}' | '#') {
-        result
+        (result, raw.to_owned())
       } else {
         fail(
           self.error(
@@ -562,35 +574,46 @@ fn @lexer.Lexer::read_hex_number(self : @lexer.Lexer) -> Int64 raise {
 }
 
 ///|
-/// Parse octal number
-fn @lexer.Lexer::read_octal_number(self : @lexer.Lexer) -> Int64 raise {
+/// Parse octal number. Returns the value and the raw source text
+/// (prefix + digits, underscores preserved) so the parser can still use the
+/// token as a bare key.
+fn @lexer.Lexer::read_octal_number(
+  self : @lexer.Lexer,
+) -> (Int64, String) raise {
 
   // (?:[0-7][0-7]*)(?:_[0-7][0-7]*)*
   // TODO(upstream): support non capturing group
   let mut result = 0L
   // 0o7__55_44 is invalid according to spec
   guard self.view() =~ (
-    re"^" +
-    re"0[oO]" +
-    (re"[0-7]+(_[0-7]+)*" as octal_digits),
+    (re"^" + re"0o" + re"[0-7]+(_[0-7]+)*") as raw,
     after=rest,
   ) else {
     fail(self.error("Invalid octal number format"))
   }
-  for ch in octal_digits {
-    if ch is '_' {
+  let mut i = 0
+  for ch in raw {
+    i = i + 1
+    if i <= 2 || ch is '_' { // skip the "0o" prefix and underscores
       continue
     }
-    result = result * 8L + (ch.to_int() - '0').to_int64()
+    let digit_value = (ch.to_int() - '0').to_int64()
+    if result > (INT64_MAX - digit_value) / 8L {
+      fail(self.error("Invalid octal number: value out of Int64 range"))
+    }
+    result = result * 8L + digit_value
   }
   self.update_view(rest)
 
   // 0-width assertion
   match self.view() {
-    [] => result
+    [] => (result, raw.to_owned())
+    // A '.' means a dotted bare key like `0o17.cd`; the parser splits the
+    // raw text, so this is not an error here.
+    ['.', ..] => (result, raw.to_owned())
     [delimited, ..] =>
       if delimited is (' ' | '\t' | '\r' | '\n' | ',' | ']' | '}' | '#') {
-        result
+        (result, raw.to_owned())
       } else {
         fail(
           self.error(
@@ -609,12 +632,21 @@ test {
     ),
   )
   let result = lexer.read_octal_number()
-  debug_inspect(result, content="493")
+  debug_inspect(
+    result,
+    content=(
+      #|(493, "0o755")
+    ),
+  )
 }
 
 ///|
-/// Parse binary number
-fn @lexer.Lexer::read_binary_number(self : @lexer.Lexer) -> Int64 raise {
+/// Parse binary number. Returns the value and the raw source text
+/// (prefix + digits, underscores preserved) so the parser can still use the
+/// token as a bare key.
+fn @lexer.Lexer::read_binary_number(
+  self : @lexer.Lexer,
+) -> (Int64, String) raise {
 
   // (?:[01][01]*)(?:_[01][01]*)*
   // TODO(upstream): support non capturing group
@@ -623,27 +655,34 @@ fn @lexer.Lexer::read_binary_number(self : @lexer.Lexer) -> Int64 raise {
   let mut result = 0L
   // 0b1__00_11 is invalid according to spec
   guard self.view() =~ (
-    re"^" +
-    re"0[bB]" +
-    (re"[01]+(_[01]+)*" as binary_digits),
+    (re"^" + re"0b" + re"[01]+(_[01]+)*") as raw,
     after=rest,
   ) else {
     fail(self.error("Invalid binary number format"))
   }
-  for ch in binary_digits {
-    if ch is '_' {
+  let mut i = 0
+  for ch in raw {
+    i = i + 1
+    if i <= 2 || ch is '_' { // skip the "0b" prefix and underscores
       continue
     }
-    result = result * 2L + (ch.to_int() - '0').to_int64()
+    let digit_value = (ch.to_int() - '0').to_int64()
+    if result > (INT64_MAX - digit_value) / 2L {
+      fail(self.error("Invalid binary number: value out of Int64 range"))
+    }
+    result = result * 2L + digit_value
   }
   self.update_view(rest)
 
   // 0-width assertion
   match self.view() {
-    [] => result
+    [] => (result, raw.to_owned())
+    // A '.' means a dotted bare key like `0b101.cd`; the parser splits the
+    // raw text, so this is not an error here.
+    ['.', ..] => (result, raw.to_owned())
     [delimited, ..] =>
       if delimited is (' ' | '\t' | '\r' | '\n' | ',' | ']' | '}' | '#') {
-        result
+        (result, raw.to_owned())
       } else {
         fail(
           self.error(
@@ -768,43 +807,24 @@ fn @lexer.Lexer::read_number_with_loc(
   let mut is_float = false
 
   // Check if this might be a special format number (0x, 0o, 0b)
+  // TOML only allows the lowercase prefixes; 0X/0O/0B fall through to the
+  // bare-key path so `x = 0X5` errors while [0XAB] stays a valid key.
   if !is_negative {
     match self.view() {
       ['0', 'x', ..] => {
-        let value = self.read_hex_number()
+        let (value, raw) = self.read_hex_number()
         let end_pos = self.get_loc()
-        return IntegerToken(
-          if is_negative {
-            -value
-          } else {
-            value
-          },
-          loc=make_loc(start_pos, end_pos),
-        )
+        return IntegerToken(value, loc=make_loc(start_pos, end_pos), raw~)
       }
       ['0', 'o', ..] => {
-        let value = self.read_octal_number()
+        let (value, raw) = self.read_octal_number()
         let end_pos = self.get_loc()
-        return IntegerToken(
-          if is_negative {
-            -value
-          } else {
-            value
-          },
-          loc=make_loc(start_pos, end_pos),
-        )
+        return IntegerToken(value, loc=make_loc(start_pos, end_pos), raw~)
       }
       ['0', 'b', ..] => {
-        let value = self.read_binary_number()
+        let (value, raw) = self.read_binary_number()
         let end_pos = self.get_loc()
-        return IntegerToken(
-          if is_negative {
-            -value
-          } else {
-            value
-          },
-          loc=make_loc(start_pos, end_pos),
-        )
+        return IntegerToken(value, loc=make_loc(start_pos, end_pos), raw~)
       }
       _ => () // continue with non binary mode
     }
@@ -813,6 +833,10 @@ fn @lexer.Lexer::read_number_with_loc(
   let raw = StringBuilder()
   if is_negative {
     raw.write_char('-')
+  } else if has_sign {
+    // Keep the '+' in the raw text: a signed number can never be a bare
+    // key, and the parser uses the raw text to tell the difference.
+    raw.write_char('+')
   }
   let next_view = for view = self.view() {
     match view {
@@ -838,13 +862,18 @@ fn @lexer.Lexer::read_number_with_loc(
     digits_so_far[digit_start] == '0' {
     let end_pos = self.get_loc()
     let loc = make_loc(start_pos, end_pos)
-    return Identifier(digits_so_far, loc~)
+    // A leading '+' means this can never be a bare key; keep the sign so
+    // the parser rejects it in key position.
+    let name = if has_sign { "+\{digits_so_far}" } else { digits_so_far }
+    return Identifier(name, loc~)
   }
 
   // Check for decimal point
+  let mut has_dot = false
   match self.view() {
     ['.', .. rest] => {
       is_float = true
+      has_dot = true
       self.update_view(rest)
       sb.write_char('.')
       raw.write_char('.')
@@ -904,10 +933,15 @@ fn @lexer.Lexer::read_number_with_loc(
     _ => ()
   }
   // If followed by identifier chars (a-z, A-Z, _, -), this is a bare key
-  // like "1key" or "2000-datetime", not a number value.
+  // like "1key", "2000-datetime" or "-5y", not a number value.
   // Use raw string (preserves underscores) for the identifier.
+  // Excluded cases:
+  // - has_sign ('+'): never a valid bare key character, leave the numeric
+  //   token to the parser, which rejects it in key position.
+  // - has_dot: "1.5x" contains '.', which is not a bare key character; the
+  //   float token followed by an identifier errors out in the parser.
   match self.view() {
-    ['a'..='z' | 'A'..='Z' | '_' | '-', ..] if !is_negative => {
+    ['a'..='z' | 'A'..='Z' | '_' | '-', ..] if !has_sign && !has_dot => {
       let next_view = for view = self.view() {
         match view {
           ['a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' as ch, .. rest] => {
@@ -926,26 +960,6 @@ fn @lexer.Lexer::read_number_with_loc(
   }
   let s = sb.to_string()
   let raw_s = raw.to_string()
-  // If the number is in key position (followed by = after whitespace),
-  // and the raw string contains characters that would be lost in numeric conversion
-  // (underscores, exponent notation), produce an Identifier to preserve the text.
-  let has_lossy_chars = raw_s != s || (is_float && !raw_s.contains("."))
-  if !is_negative && !has_sign && has_lossy_chars {
-    let is_key = for view = self.view() {
-      match view {
-        [' ' | '\t', .. rest] => continue rest
-        ['=' | '.', ..] => break true // key = value or dotted.key
-        // ] followed by newline/EOF indicates table header [key], not array
-        [']', '\n' | '\r', ..] | [']'] => break true
-        _ => break false
-      }
-    }
-    if is_key {
-      let end_pos = self.get_loc()
-      let loc = make_loc(start_pos, end_pos)
-      return Identifier(raw_s, loc~)
-    }
-  }
   if is_float {
     validate_float_string(s, raw_s) catch {
       e => fail(self.error(e.to_string()))
@@ -969,7 +983,7 @@ fn @lexer.Lexer::read_number_with_loc(
       raw=raw_s,
     )
   } else {
-    IntegerToken(@string.parse_int64(s), loc~) catch {
+    IntegerToken(@string.parse_int64(s), loc~, raw=raw_s) catch {
       _ => fail("Invalid integer: \{s}")
     }
   }
@@ -1140,6 +1154,7 @@ test "read_number" {
       #|IntegerToken(
       #|  123,
       #|  loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 4 } },
+      #|  raw="123",
       #|)
     ),
   )
@@ -1276,30 +1291,18 @@ fn @lexer.Lexer::next_token(self : @lexer.Lexer) -> Token raise {
       }
 
     // Positive numbers with explicit '+' (only decimal, not 0x/0o/0b).
-    // '+' is not a valid bare key character, so +number in key position
-    // (followed by = or ]) should be rejected.
-    ['+', '0'..='9', ..] => {
-      // Peek ahead: skip digits/underscores, then check for key indicators
-      let is_key_context = for view = self.view()[1:] {
-        match view {
-          ['0'..='9' | '_', .. rest] => continue rest
-          [' ' | '\t', .. rest] => continue rest
-          ['=' | ']', ..] => break true // +num= or [+num] are both invalid
-          _ => break false
-        }
-      }
-      if is_key_context {
-        fail("Unexpected character: '+'")
-      }
+    // '+' is not a valid bare key character; the raw text keeps the sign so
+    // the parser can reject this token in key position (e.g. `+5 = 3`).
+    ['+', '0'..='9', ..] =>
       match self.view() {
-        ['+', '0', 'x' | 'o' | 'b', ..] => fail("Unexpected character: '+'")
+        ['+', '0', 'x' | 'X' | 'o' | 'O' | 'b' | 'B', ..] =>
+          fail("Unexpected character: '+'")
         ['+', .. rest] => {
           self.update_view(rest)
-          self.read_number_with_loc(false, start_pos)
+          self.read_number_with_loc(false, start_pos, has_sign=true)
         }
         _ => abort("Internal error: pattern matching inconsistency")
       }
-    }
 
     // Handle negative special float values (-inf, -nan)
     ['-', 'i', 'n', 'f', .. rest] => {
@@ -1375,6 +1378,7 @@ test "read_number 2" {
       #|IntegerToken(
       #|  123,
       #|  loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 4 } },
+      #|  raw="123",
       #|)
     ),
   )
@@ -1487,7 +1491,12 @@ test "identifier parsing" {
 test "hex number parsing" {
   let lexer = @lexer.Lexer::Lexer("0xDEADBEEF")
   let result = lexer.read_hex_number()
-  debug_inspect(result, content="3735928559")
+  debug_inspect(
+    result,
+    content=(
+      #|(3735928559, "0xDEADBEEF")
+    ),
+  )
 }
 
 ///|
@@ -1495,7 +1504,12 @@ test "hex number parsing" {
 test "octal number parsing" {
   let lexer = @lexer.Lexer::Lexer("0o755")
   let result = lexer.read_octal_number()
-  debug_inspect(result, content="493")
+  debug_inspect(
+    result,
+    content=(
+      #|(493, "0o755")
+    ),
+  )
 }
 
 ///|
@@ -1503,7 +1517,12 @@ test "octal number parsing" {
 test "binary number parsing" {
   let lexer = @lexer.Lexer::Lexer("0b1010")
   let result = lexer.read_binary_number()
-  debug_inspect(result, content="10")
+  debug_inspect(
+    result,
+    content=(
+      #|(10, "0b1010")
+    ),
+  )
 }
 
 ///|

--- a/key_value_disambiguation_test.mbt
+++ b/key_value_disambiguation_test.mbt
@@ -1,0 +1,267 @@
+///|
+/// Regression tests for number-like tokens that must work both as values and
+/// as bare keys. The tokenizer keeps the raw source text on numeric tokens
+/// and the parser decides from the grammatical context; previously the
+/// tokenizer guessed the context with a lookahead that misclassified
+/// numbers in several positions.
+
+///|
+test "underscored or exponent numbers as last array element" {
+  // These used to fail with "Expected value": a number followed by `]` and
+  // newline/EOF was mistaken for a table-header key.
+  debug_inspect(
+    @toml.parse("arr = [1_0]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlInteger(10)]) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("arr = [1_000.5]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlFloat(1000.5)]) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("arr = [1e3]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlFloat(1000)]) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("arr = [\n  1_000.5,\n  2.5_5,\n]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlFloat(1000.5), TomlFloat(2.55)]) })
+    ),
+  )
+}
+
+///|
+test "'+' signed numbers as last array element" {
+  // The old key-position lookahead rejected any `+number]` at end of line.
+  debug_inspect(
+    @toml.parse("arr = [+5]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlInteger(5)]) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("arr = [+5.5]\n"),
+    content=(
+      #|TomlTable({ "arr": TomlArray([TomlFloat(5.5)]) })
+    ),
+  )
+}
+
+///|
+test "number-like bare keys keep their raw text" {
+  debug_inspect(
+    @toml.parse("[1_0]\nx = 1\n"),
+    content=(
+      #|TomlTable({ "1_0": TomlTable({ "x": TomlInteger(1) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("[-1_0]\nx = 1\n"),
+    content=(
+      #|TomlTable({ "-1_0": TomlTable({ "x": TomlInteger(1) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("[0xAB]\nx = 1\n"),
+    content=(
+      #|TomlTable({ "0xAB": TomlTable({ "x": TomlInteger(1) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("0xAB.cd = 1\n"),
+    content=(
+      #|TomlTable({ "0xAB": TomlTable({ "cd": TomlInteger(1) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("1_000.5 = 3\n"),
+    content=(
+      #|TomlTable({ "1_000": TomlTable({ "5": TomlInteger(3) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("-5y = 3\n"),
+    content=(
+      #|TomlTable({ "-5y": TomlInteger(3) })
+    ),
+  )
+}
+
+///|
+test "uppercase hex octal binary prefixes are not numbers" {
+  // TOML only allows lowercase 0x/0o/0b prefixes, so 0X/0O/0B in value
+  // position is an error...
+  for input in ["x = 0XDEAD\n", "x = 0O755\n", "x = 0B1010\n"] {
+    assert_true(parse_expect_to_fail(input).has_prefix("Expected value"))
+  }
+  // ...but they are still valid bare keys.
+  debug_inspect(
+    @toml.parse("[0XAB]\nx = 1\n"),
+    content=(
+      #|TomlTable({ "0XAB": TomlTable({ "x": TomlInteger(1) }) })
+    ),
+  )
+}
+
+///|
+test "'+' signed numbers are never bare keys" {
+  // '+' is not a bare-key character, so all of these must be rejected
+  // (several used to parse with the '+' silently dropped).
+  inspect(
+    parse_expect_to_fail("+5 = 3\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 3 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("+5.5 = 3\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("+5e3 = 3\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("+5y = 3\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 3 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("[+5]\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 2 }, end: { line: 1, column: 4 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("+inf = 1\n"),
+    content=(
+      #|Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } })
+    ),
+  )
+}
+
+///|
+test "signed number values still work" {
+  debug_inspect(
+    @toml.parse("x = +5\ny = -5\n"),
+    content=(
+      #|TomlTable({ "x": TomlInteger(5), "y": TomlInteger(-5) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("x = +5.5\ny = -5.5\n"),
+    content=(
+      #|TomlTable({ "x": TomlFloat(5.5), "y": TomlFloat(-5.5) })
+    ),
+  )
+}
+
+///|
+test "hex octal binary overflow is rejected" {
+  // These used to silently wrap around (0xFFFFFFFFFFFFFFFF parsed as -1)
+  // while decimal overflow was already an error.
+  inspect(
+    parse_expect_to_fail("x = 0xFFFFFFFFFFFFFFFF\n"),
+    content=(
+      #|Invalid hex number: value out of Int64 range at line 1, column 5)
+    ),
+  )
+  inspect(
+    parse_expect_to_fail(
+      "x = 0b1111111111111111111111111111111111111111111111111111111111111111\n",
+    ),
+    content=(
+      #|Invalid binary number: value out of Int64 range at line 1, column 5)
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("x = 0o2000000000000000000000\n"),
+    content=(
+      #|Invalid octal number: value out of Int64 range at line 1, column 5)
+    ),
+  )
+  // The boundaries of the Int64 range still parse.
+  debug_inspect(
+    @toml.parse("x = 0x7FFFFFFFFFFFFFFF\n"),
+    content=(
+      #|TomlTable({ "x": TomlInteger(9223372036854775807) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("x = -9223372036854775808\n"),
+    content=(
+      #|TomlTable({ "x": TomlInteger(-9223372036854775808) })
+    ),
+  )
+}
+
+///|
+test "dotted-key tables cannot be reopened by headers" {
+  // TOML 1.0: dotted keys define the tables for each key part, and such
+  // tables cannot be redefined with a [table] header.
+  inspect(
+    parse_expect_to_fail("fruit.apple = 1\n\n[fruit]\n"),
+    content=(
+      #|Duplicate table definition: [fruit] at { start: { line: 3, column: 8 }, end: { line: 4, column: 1 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("a.b.c = 1\n[a]\n"),
+    content=(
+      #|Duplicate table definition: [a] at { start: { line: 2, column: 4 }, end: { line: 3, column: 1 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("a.b.c = 1\n[a.b]\n"),
+    content=(
+      #|Duplicate table definition: [a.b] at { start: { line: 2, column: 6 }, end: { line: 3, column: 1 } })
+    ),
+  )
+  inspect(
+    parse_expect_to_fail("[[a]]\nb.c = 1\n[a.b]\n"),
+    content=(
+      #|Duplicate table definition: [a.b] at { start: { line: 3, column: 6 }, end: { line: 4, column: 1 } })
+    ),
+  )
+}
+
+///|
+test "implicit super-tables from headers can still be defined" {
+  // Tables created implicitly by [a.b] headers (not by dotted keys) may be
+  // defined by a later [a] header.
+  debug_inspect(
+    @toml.parse("[a.b]\nx = 1\n[a]\ny = 2\n"),
+    content=(
+      #|TomlTable({ "a": TomlTable({ "b": TomlTable({ "x": TomlInteger(1) }), "y": TomlInteger(2) }) })
+    ),
+  )
+  // Defining a new sub-table under a dotted-key table is also fine.
+  debug_inspect(
+    @toml.parse("a.b = 1\n[a.c]\nx = 2\n"),
+    content=(
+      #|TomlTable({ "a": TomlTable({ "b": TomlInteger(1), "c": TomlTable({ "x": TomlInteger(2) }) }) })
+    ),
+  )
+}
+
+///|
+test "static arrays cannot be appended by array-of-tables headers" {
+  // `[[a]]` may only append to arrays it created, never to a static array,
+  // even a static array of inline tables.
+  for
+    input in [
+      "a = []\n[[a]]\n", "a = [{}]\n[[a]]\n", "a = [ {x = 1} ]\n[[a]]\ny = 2\n",
+    ] {
+    assert_true(parse_expect_to_fail(input).has_prefix("ExpectedArray"))
+  }
+}

--- a/key_value_disambiguation_test.mbt
+++ b/key_value_disambiguation_test.mbt
@@ -265,3 +265,65 @@ test "static arrays cannot be appended by array-of-tables headers" {
     assert_true(parse_expect_to_fail(input).has_prefix("ExpectedArray"))
   }
 }
+
+///|
+test "bare keys are not subject to numeric underscore or range rules" {
+  // Bare keys only require A-Za-z0-9_- characters; underscore placement and
+  // Int64 range are numeric-literal rules and do not apply in key position.
+  // (Regression: these used to fail numeric validation before the parser
+  // could use the raw text as a key.)
+  debug_inspect(
+    @toml.parse("1__0 = 1\n"),
+    content=(
+      #|TomlTable({ "1__0": TomlInteger(1) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("[1_]\nx = 2\n"),
+    content=(
+      #|TomlTable({ "1_": TomlTable({ "x": TomlInteger(2) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("1_.5 = 3\n"),
+    content=(
+      #|TomlTable({ "1_": TomlTable({ "5": TomlInteger(3) }) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("99999999999999999999 = 1\n"),
+    content=(
+      #|TomlTable({ "99999999999999999999": TomlInteger(1) })
+    ),
+  )
+  debug_inspect(
+    @toml.parse("-99999999999999999999 = 1\n"),
+    content=(
+      #|TomlTable({ "-99999999999999999999": TomlInteger(1) })
+    ),
+  )
+}
+
+///|
+test "numeric validation still applies in value position" {
+  // The same texts are invalid as values — and the error keeps the specific
+  // reason rather than degrading to a generic "Expected value".
+  debug_inspect(
+    [
+      parse_expect_to_fail("x = 1__0\n"),
+      parse_expect_to_fail("arr = [1__0]\n"),
+      parse_expect_to_fail("x = 1_\n"),
+      parse_expect_to_fail("x = 1.5_\n"),
+      parse_expect_to_fail("x = 99999999999999999999\n"),
+    ],
+    content=(
+      #|[
+      #|  "Failure(Invalid number: underscore not between digits) at { start: { line: 1, column: 5 }, end: { line: 1, column: 9 } })",
+      #|  "Failure(Invalid number: underscore not between digits) at { start: { line: 1, column: 8 }, end: { line: 1, column: 12 } })",
+      #|  "Failure(Invalid number: trailing underscore) at { start: { line: 1, column: 5 }, end: { line: 1, column: 7 } })",
+      #|  "Failure(Invalid number: trailing underscore) at { start: { line: 1, column: 5 }, end: { line: 1, column: 9 } })",
+      #|  "Failure(Invalid integer: 99999999999999999999) at { start: { line: 1, column: 5 }, end: { line: 1, column: 25 } })",
+      #|]
+    ),
+  )
+}

--- a/parser.mbt
+++ b/parser.mbt
@@ -76,11 +76,21 @@ fn Parser::parse_value(
       self.update_view(rest)
       TomlString(s)
     }
-    [IntegerToken(i, ..), .. rest] => {
+    [IntegerToken(i, raw~, ..), .. rest] => {
+      // Numeric rules (underscore placement, Int64 range) apply only when
+      // the token is used as a value; in key position the raw text is used
+      // verbatim and never validated.
+      @tokenize.validate_integer_literal(raw) catch {
+        e => self.error(e.to_string())
+      }
       self.update_view(rest)
       TomlInteger(i)
     }
     [FloatToken(f, raw~, ..), .. rest] => {
+      // As above: dot/underscore rules apply to values only.
+      @tokenize.validate_float_literal(raw) catch {
+        e => self.error(e.to_string())
+      }
       // Reject overflow: non-finite values are only valid with the
       // canonical spellings inf/nan/+inf/-inf/+nan/-nan.
       if (f.is_inf() || f.is_nan()) &&

--- a/parser.mbt
+++ b/parser.mbt
@@ -14,31 +14,46 @@ fn Parser::skip_newlines(self : Parser) -> Unit {
 /// Try to consume a single bare key from the current position.
 /// Handles identifiers, strings, integers, booleans (true/false),
 /// and special float keywords (inf/nan) in key position.
+///
+/// The raw source text of numeric tokens is used as the key so that
+/// underscores and other digit formatting are preserved (`1_0` stays
+/// "1_0"). A leading '+' in the raw text means the token can never be a
+/// bare key ('+' is not a bare-key character), so it is rejected here and
+/// surfaces as an "Expected key" error.
 fn Parser::try_parse_single_key(self : Parser) -> String? {
   match self.view() {
-    [Identifier(name, ..), .. rest] => {
-      self.update_view(rest)
-      Some(name)
-    }
+    [Identifier(name, ..), .. rest] =>
+      if name.has_prefix("+") {
+        None
+      } else {
+        self.update_view(rest)
+        Some(name)
+      }
     [StringToken(_, multiline=true, ..), ..] => None // multiline strings not allowed as keys
     [StringToken(name, ..), .. rest] => {
       self.update_view(rest)
       Some(name)
     }
-    [IntegerToken(i, ..), .. rest] => {
-      self.update_view(rest)
-      Some(i.to_string())
-    }
+    [IntegerToken(_, raw~, ..), .. rest] =>
+      if raw.has_prefix("+") {
+        None
+      } else {
+        self.update_view(rest)
+        Some(raw)
+      }
     [BooleanToken(b, ..), .. rest] => {
       self.update_view(rest)
       Some(if b { "true" } else { "false" })
     }
-    [FloatToken(_, raw~, ..), .. rest] => {
+    [FloatToken(_, raw~, ..), .. rest] =>
       // Use the raw source text so that tokens like -10e-1 (which the
       // lexer parses as a float) can still serve as bare keys.
-      self.update_view(rest)
-      Some(raw)
-    }
+      if raw.has_prefix("+") {
+        None
+      } else {
+        self.update_view(rest)
+        Some(raw)
+      }
     [DateTimeToken(LocalDate(s), ..), .. rest] => {
       // Only LocalDate (YYYY-MM-DD) is valid as a bare key — it only
       // contains digits and dashes. Other datetime variants contain
@@ -206,6 +221,10 @@ fn Parser::parse_dotted_key(self : Parser) -> Array[String] raise {
     [FloatToken(_, raw~, ..), .. rest] => {
       // Use the raw source text so dotted numeric keys like "1.2" split
       // correctly and tokens like -10e-1 are preserved verbatim.
+      // A leading '+' is never valid in a bare key.
+      if raw.has_prefix("+") {
+        self.error("Expected key")
+      }
       self.update_view(rest)
       match raw.split_once(".") {
         Some((left, right)) => {
@@ -230,6 +249,10 @@ fn Parser::parse_dotted_key(self : Parser) -> Array[String] raise {
         // Check for float token (e.g. 1.2 → keys "1" and "2")
         match self.view() {
           [FloatToken(_, raw~, ..), .. rest2] => {
+            // A leading '+' is never valid in a bare key.
+            if raw.has_prefix("+") {
+              self.error("Expected key after dot")
+            }
             self.update_view(rest2)
             let float_str = raw
             match float_str.split_once(".") {
@@ -360,14 +383,11 @@ pub fn parse(input : String) -> TomlValue raise {
       _ => {
         // Parse key-value pair
         let (key_path, value) = parser.parse_key_value()
-        // Mark implicit tables when inside an explicitly defined [table] section
-        let in_defined_section = current_table.contains(table_defined_marker)
-        set_dotted_key_value(
-          current_table,
-          key_path,
-          value,
-          mark_implicit=in_defined_section,
-        ) catch {
+        // Tables created by dotted keys count as defined: they cannot be
+        // reopened with [table] headers later (TOML 1.0 "tables cannot be
+        // defined more than once"), and dotted keys in one section cannot
+        // extend a table that a [table] header defined in another section.
+        set_dotted_key_value(current_table, key_path, value, mark_implicit=true) catch {
           error => parser.error("\{error}")
         }
         // Validate that key-value pair is properly terminated

--- a/parser_test.mbt
+++ b/parser_test.mbt
@@ -253,9 +253,10 @@ test "tokenize exponent-like bare keys" {
     @tokenize.tokenize("10e-1 = \"a\""),
     content=(
       #|[
-      #|  Identifier(
-      #|    "10e-1",
+      #|  FloatToken(
+      #|    1,
       #|    loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 6 } },
+      #|    raw="10e-1",
       #|  ),
       #|  Equals(loc={ start: { line: 1, column: 7 }, end: { line: 1, column: 8 } }),
       #|  StringToken(
@@ -271,9 +272,10 @@ test "tokenize exponent-like bare keys" {
     @tokenize.tokenize("10e1 = \"b\""),
     content=(
       #|[
-      #|  Identifier(
-      #|    "10e1",
+      #|  FloatToken(
+      #|    100,
       #|    loc={ start: { line: 1, column: 1 }, end: { line: 1, column: 5 } },
+      #|    raw="10e1",
       #|  ),
       #|  Equals(loc={ start: { line: 1, column: 6 }, end: { line: 1, column: 7 } }),
       #|  StringToken(
@@ -421,7 +423,8 @@ test "overflow float accepted as bare key" {
 
 ///|
 test "special float keywords as keys" {
-  // inf, nan, +inf, -inf, etc. are valid bare keys in TOML
+  // inf, nan, -inf, etc. are valid bare keys in TOML, but +inf is not:
+  // '+' is not a bare-key character, so `+inf = 1` must be rejected.
   debug_inspect(
     try @toml.parse("+inf = 1\n") catch {
       err => Err(err)
@@ -429,7 +432,7 @@ test "special float keywords as keys" {
       value => Ok(value)
     },
     content=(
-      #|Ok(TomlTable({ "+inf": TomlInteger(1) }))
+      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } }"))
     ),
   )
   debug_inspect(
@@ -686,6 +689,8 @@ test "dotted key notation integer keys" {
 
 ///|
 /// Test dotted key notation - conflict with table headers
+/// `a.b = ...` defines the table `a`, so reopening it with a `[a]` header
+/// is a duplicate definition and must be rejected (TOML 1.0).
 test "dotted key notation table conflict" {
   let conflict_toml =
     #|a.b = "dotted"
@@ -693,9 +698,13 @@ test "dotted key notation table conflict" {
     #|c = "table"
     #|
   debug_inspect(
-    @toml.parse(conflict_toml),
+    try @toml.parse(conflict_toml) catch {
+      err => Err(err)
+    } noraise {
+      value => Ok(value)
+    },
     content=(
-      #|TomlTable({ "a": TomlTable({ "b": TomlString("dotted"), "c": TomlString("table") }) })
+      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Duplicate table definition: [a] at { start: { line: 2, column: 4 }, end: { line: 3, column: 1 } }"))
     ),
   )
 }

--- a/parser_test.mbt
+++ b/parser_test.mbt
@@ -432,7 +432,7 @@ test "special float keywords as keys" {
       value => Ok(value)
     },
     content=(
-      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } }"))
+      #|Err(Failure("parser.mbt:219:20-219:70@bobzhang/toml FAILED: Expected key at { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } }"))
     ),
   )
   debug_inspect(
@@ -704,7 +704,7 @@ test "dotted key notation table conflict" {
       value => Ok(value)
     },
     content=(
-      #|Err(Failure("parser.mbt:209:20-209:70@bobzhang/toml FAILED: Duplicate table definition: [a] at { start: { line: 2, column: 4 }, end: { line: 3, column: 1 } }"))
+      #|Err(Failure("parser.mbt:219:20-219:70@bobzhang/toml FAILED: Duplicate table definition: [a] at { start: { line: 2, column: 4 }, end: { line: 3, column: 1 } }"))
     ),
   )
 }

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -137,10 +137,19 @@ fn create_array_of_tables(
   let new_table = Map([])
   match current_table.get(final_key) {
     Some(TomlArray(existing_array)) => {
-      // Verify this is an array-of-tables (created by [[ ]]), not a static array (= [...])
-      // Static arrays are either empty or contain non-table values
+      // Verify this is an array-of-tables (created by [[ ]]), not a static
+      // array (= [...]). Static arrays are either empty or contain
+      // non-table values; a static array of inline tables is immutable as
+      // well, and its elements carry the inline-table marker.
       let is_array_of_tables = existing_array.length() > 0 &&
-        existing_array.iter().all(fn(v) { v is TomlTable(_) })
+        existing_array
+        .iter()
+        .all(fn(v) {
+          match v {
+            TomlTable(t) => !t.contains("\u0000__inline__")
+            _ => false
+          }
+        })
       if !is_array_of_tables {
         raise ExpectedArray(final_key, TomlArray(existing_array))
       }


### PR DESCRIPTION
## Summary

Found by auditing the tokenizer/parser against Python's `tomllib` and the official toml-test suite. Root cause of the first group: the tokenizer guessed key-vs-value position with a local lookahead (a number followed by `]`+newline was assumed to be a `[header]` key) and reshaped tokens accordingly. Now `IntegerToken` carries the raw source text (like `FloatToken` already did) and the **parser** decides from the grammatical context.

## Bugs fixed

**Valid documents that were rejected**

- `arr = [1_0]`, `arr = [1_000.5]`, `arr = [1e3]` — underscored/exponent numbers as the last array element errored with "Expected value"
- `arr = [+5]` — rejected by the `+` key-position lookahead
- `0xAB.cd = 1` — hex-looking dotted keys errored in the hex reader

**Wrong results (silent corruption)**

- `x = 0xFFFFFFFFFFFFFFFF` parsed as `-1` (hex/octal/binary accumulation wrapped on Int64 overflow; decimal overflow was already an error). Now raises `value out of Int64 range`
- `[0xAB]` produced key `"171"` instead of `"0xAB"`; `[-1_0]` produced `"-10"`; `1_000.5 = 3` produced one key `"1_000.5"` instead of dotted `1_000` / `5`

**Invalid documents that were accepted**

- `+5 = 3`, `+5.5 = 3`, `+5e3 = 3`, `+inf = 1` — `'+'` is not a bare-key character
- `fruit.apple = 1` followed by `[fruit]` (also `a.b.c = 1` + `[a]`/`[a.b]`, and inside `[[a]]` elements) — dotted keys define their tables; headers cannot reopen them (TOML 1.0)
- `a = [{}]` followed by `[[a]]` — `[[ ]]` appended to a static array of inline tables

**Also**

- `0X`/`0O`/`0B` prefixes kept lowercase-only per spec (`hex-prefix = %x30.78`); they still work as bare keys (`[0XAB]`)
- `-5y = 3` (dashed bare key starting with `-`) parses again
- Two pre-existing tests asserted the buggy behavior and were updated: `+inf = 1` as a key, and the `a.b = ...` + `[a]` "conflict" test
- The old "hex overflow edge case" test snapshotted `IntegerToken(-1)` — the bug itself; now asserts the error

## Verification

Each case cross-checked against `tomllib` (e.g. `Cannot declare ('fruit',) twice`, `Cannot mutate immutable namespace ('a',)`).

- `moon test` (wasm-gc): 407/407
- `moon test --target native`: 409/409
- `moon test e2e --target native`: 262/262 valid, 474/483 invalid — the remaining 9 are the pre-existing intentional TOML 1.1 features (optional seconds, `\x` escapes, inline-table newlines/trailing comma)
- `moon check --deny-warn --target all`, `moon fmt`, `moon info`, `moon cram test --release tests/cram` all clean
- New regression tests in `key_value_disambiguation_test.mbt`
