### PR TITLE
feat(quickcheck): companion property-testing package (RFC #115, Option C)

### DIFF
--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -35,7 +35,7 @@ is the standard escape hatch — the same pattern `moonbitlang/quickcheck`'s own
 test "documents survive a parse round-trip" {
   @qc.quick_check_fn(
     fn(document : @quickcheck.RoundTrippable) {
-      @quickcheck.round_trips(document.inner())
+      @quickcheck.round_trips(document.0)
     },
     max_success=100,
   )

--- a/quickcheck/README.mbt.md
+++ b/quickcheck/README.mbt.md
@@ -1,0 +1,62 @@
+# `bobzhang/toml/quickcheck`
+
+Property-testing support for [`bobzhang/toml`](../), kept in a **companion
+package** so the core parser stays free of any quickcheck dependency — you only
+pull `moonbitlang/quickcheck` (and its transitive weight) when you actually
+import this package.
+
+## What it provides
+
+- `roundtrippable_document() : @gen.Gen[@toml.TomlValue]` — a generator for the
+  round-trip-safe fragment of TOML (every primitive, homogeneous arrays, nested
+  tables, and adversarial keys; **no** floats or mixed arrays, so exact
+  equality is meaningful).
+- `shrink_document(doc) : Iter[@toml.TomlValue]` — the matching shrinker.
+- `round_trips(value) : Bool` — the law `parse(v.to_string()) == v` as a
+  predicate (parser errors caught as `false`).
+- `RoundTrippable` — a newtype over `TomlValue` carrying the `Arbitrary` and
+  `Shrink` trait instances, for the ergonomic `quick_check_fn` runner.
+
+### Why a newtype?
+
+A companion package cannot write `impl Arbitrary for TomlValue`: both the trait
+(`moonbitlang/core/quickcheck`) and the type (`bobzhang/toml`) are foreign to
+it, which the orphan rule forbids. Wrapping `TomlValue` in a **local** newtype
+is the standard escape hatch — the same pattern `moonbitlang/quickcheck`'s own
+`modifiers` package uses (`Positive`, `NonEmptyArray`, ...).
+
+## Idiom 1 — trait-driven runner
+
+`quick_check_fn` reads the generator and shrinker straight off the
+`RoundTrippable` instances, so you only name the property:
+
+```mbt check
+///|
+test "documents survive a parse round-trip" {
+  @qc.quick_check_fn(
+    fn(document : @quickcheck.RoundTrippable) {
+      @quickcheck.round_trips(document.inner())
+    },
+    max_success=100,
+  )
+}
+```
+
+## Idiom 2 — explicit generators
+
+When you want to combine several generators, or skip the newtype, hand the
+generator and shrinker to `forall_shrink` directly:
+
+```mbt check
+///|
+test "documents survive a parse round-trip (explicit)" {
+  @qc.quick_check(
+    @qc.forall_shrink(
+      @quickcheck.roundtrippable_document(),
+      @quickcheck.shrink_document,
+      fn(value) { @quickcheck.round_trips(value) },
+    ),
+    max_success=100,
+  )
+}
+```

--- a/quickcheck/README.md
+++ b/quickcheck/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/quickcheck/gen.mbt
+++ b/quickcheck/gen.mbt
@@ -1,0 +1,323 @@
+///|
+/// Generators for the *round-trip-safe* fragment of `@toml.TomlValue`.
+///
+/// These are plain `@gen.Gen` values, so they compose with the full
+/// quickcheck API directly — pass one to `@qc.forall_shrink`, or reach for the
+/// `RoundTrippable` newtype (see `roundtrippable.mbt`) to drive the
+/// trait-based `@qc.quick_check_fn` runner.
+///
+/// The fragment deliberately excludes `TomlFloat` (formatting loses exact
+/// equality) and heterogeneous arrays (rejected by TOML), so every value this
+/// module produces satisfies the law `parse(v.to_string()) == v`.
+
+///|
+fn capped(size : Int, cap : Int) -> Int {
+  if size < cap {
+    size
+  } else {
+    cap
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keys
+// ---------------------------------------------------------------------------
+
+///|
+fn key_from_parts(head : Char, tail : Array[Char]) -> String {
+  let builder = StringBuilder()
+  builder.write_char(head)
+  for ch in tail {
+    builder.write_char(ch)
+  }
+  builder.to_string()
+}
+
+///|
+fn bare_key_char() -> @gen.Gen[Char] {
+  @gen.one_of([
+    @gen.char_range('a', 'z'),
+    @gen.char_range('0', '9'),
+    @gen.pure('-'),
+    @gen.pure('_'),
+  ])
+}
+
+///|
+/// A TOML "bare" identifier: a leading letter followed by up to a few
+/// `[a-z0-9_-]` characters.
+fn bare_key() -> @gen.Gen[String] {
+  @gen.sized(fn(size) {
+    @gen.int_range(0, capped(size, 4) + 1).bind(fn(tail_len) {
+      @gen.liftA2(
+        key_from_parts,
+        @gen.char_range('a', 'z'),
+        bare_key_char().array_with_size(tail_len),
+      )
+    })
+  })
+}
+
+///|
+fn key_with_middle(middle : Char) -> @gen.Gen[String] {
+  @gen.liftA3(
+    fn(left : String, mid : Char, right : String) {
+      left + mid.to_string() + right
+    },
+    bare_key(),
+    @gen.pure(middle),
+    bare_key(),
+  )
+}
+
+///|
+/// A key that forces the serializer to quote it (embedded space, dot, or
+/// quote character).
+fn complex_key() -> @gen.Gen[String] {
+  @gen.frequency([
+    (2U, key_with_middle(' ')),
+    (2U, key_with_middle('.')),
+    (1U, key_with_middle('"')),
+  ])
+}
+
+///|
+/// A key that looks like a negative float literal (e.g. `-3e7`). These collide
+/// with the float grammar at the lexer level and are a classic ambiguity trap.
+fn negative_exponent_like_key() -> @gen.Gen[String] {
+  @gen.liftA2(
+    fn(significand : Int, exponent : Int) { "-\{significand}e\{exponent}" },
+    @gen.int_range(1, 1000),
+    @gen.int_range(0, 1000),
+  )
+}
+
+///|
+fn key() -> @gen.Gen[String] {
+  @gen.frequency([
+    (3U, bare_key()),
+    (2U, complex_key()),
+    (1U, negative_exponent_like_key()),
+  ])
+}
+
+// ---------------------------------------------------------------------------
+// Datetimes
+// ---------------------------------------------------------------------------
+
+///|
+fn pad2(value : Int) -> String {
+  if value < 10 {
+    "0\{value}"
+  } else {
+    "\{value}"
+  }
+}
+
+///|
+fn pad4(value : Int) -> String {
+  if value < 10 {
+    "000\{value}"
+  } else if value < 100 {
+    "00\{value}"
+  } else if value < 1000 {
+    "0\{value}"
+  } else {
+    "\{value}"
+  }
+}
+
+///|
+// Day is capped at 28 so every (year, month) pair is valid without a
+// days-in-month / leap-year table.
+fn date_string() -> @gen.Gen[String] {
+  @gen.liftA3(
+    fn(year, month, day) { "\{pad4(year)}-\{pad2(month)}-\{pad2(day)}" },
+    @gen.int_range(1, 10000),
+    @gen.int_range(1, 13),
+    @gen.int_range(1, 29),
+  )
+}
+
+///|
+fn fractional_seconds() -> @gen.Gen[String] {
+  @gen.frequency([
+    (2U, @gen.pure("")),
+    (
+      1U,
+      @gen.int_range(1, 7).bind(fn(len) {
+        @gen.char_range('0', '9')
+        .array_with_size(len)
+        .fmap(fn(digits) {
+          let builder = StringBuilder()
+          builder.write_char('.')
+          for digit in digits {
+            builder.write_char(digit)
+          }
+          builder.to_string()
+        })
+      }),
+    ),
+  ])
+}
+
+///|
+fn time_string() -> @gen.Gen[String] {
+  @gen.liftA2(
+    fn(base, fraction) { base + fraction },
+    @gen.liftA3(
+      fn(hour, minute, second) {
+        "\{pad2(hour)}:\{pad2(minute)}:\{pad2(second)}"
+      },
+      @gen.int_range(0, 24),
+      @gen.int_range(0, 60),
+      @gen.int_range(0, 60),
+    ),
+    fractional_seconds(),
+  )
+}
+
+///|
+fn offset_string() -> @gen.Gen[String] {
+  @gen.frequency([
+    (2U, @gen.pure("Z")),
+    (
+      1U,
+      @gen.liftA2(
+        fn(hour, minute) { "+\{pad2(hour)}:\{pad2(minute)}" },
+        @gen.int_range(0, 24),
+        @gen.int_range(0, 60),
+      ),
+    ),
+    (
+      1U,
+      @gen.liftA2(
+        fn(hour, minute) { "-\{pad2(hour)}:\{pad2(minute)}" },
+        @gen.int_range(0, 24),
+        @gen.int_range(0, 60),
+      ),
+    ),
+  ])
+}
+
+///|
+fn datetime() -> @gen.Gen[@datetime.TomlDateTime] {
+  @gen.frequency([
+    (2U, date_string().fmap(fn(text) { LocalDate(text) })),
+    (2U, time_string().fmap(fn(text) { LocalTime(text) })),
+    (
+      2U,
+      @gen.liftA2(
+        fn(date, time) { LocalDateTime("\{date}T\{time}") },
+        date_string(),
+        time_string(),
+      ),
+    ),
+    (
+      2U,
+      @gen.liftA3(
+        fn(date, time, offset) { OffsetDateTime("\{date}T\{time}\{offset}") },
+        date_string(),
+        time_string(),
+        offset_string(),
+      ),
+    ),
+  ])
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+///|
+fn string_value() -> @gen.Gen[@toml.TomlValue] {
+  let strings : @gen.Gen[String] = @gen.Gen::spawn()
+  strings.scale(fn(n) { capped(n, 8) }).fmap(fn(s) { TomlString(s) })
+}
+
+///|
+fn integer_value() -> @gen.Gen[@toml.TomlValue] {
+  let integers : @gen.Gen[Int64] = @gen.Gen::spawn()
+  integers.fmap(fn(n) { TomlInteger(n) })
+}
+
+///|
+fn boolean_value() -> @gen.Gen[@toml.TomlValue] {
+  let booleans : @gen.Gen[Bool] = @gen.Gen::spawn()
+  booleans.fmap(fn(b) { TomlBoolean(b) })
+}
+
+///|
+fn datetime_value() -> @gen.Gen[@toml.TomlValue] {
+  datetime().fmap(fn(dt) { TomlDateTime(dt) })
+}
+
+///|
+fn non_empty_length(size : Int) -> @gen.Gen[Int] {
+  @gen.int_range(1, capped(size + 1, 4) + 1)
+}
+
+///|
+fn homogeneous_array(
+  size : Int,
+  element : @gen.Gen[@toml.TomlValue],
+) -> @gen.Gen[@toml.TomlValue] {
+  non_empty_length(size).bind(fn(len) {
+    element.array_with_size(len).fmap(fn(items) { TomlArray(items) })
+  })
+}
+
+///|
+fn scalar_or_array(size : Int) -> @gen.Gen[@toml.TomlValue] {
+  @gen.frequency([
+    (3U, string_value()),
+    (2U, integer_value()),
+    (2U, boolean_value()),
+    (2U, datetime_value()),
+    (1U, @gen.pure(TomlArray([]))),
+    (2U, homogeneous_array(size, string_value())),
+    (2U, homogeneous_array(size, integer_value())),
+    (2U, homogeneous_array(size, boolean_value())),
+    (2U, homogeneous_array(size, datetime_value())),
+  ])
+}
+
+///|
+fn entry(size : Int) -> @gen.Gen[(String, @toml.TomlValue)] {
+  @gen.liftA2(fn(k, v) { (k, v) }, key(), value(size))
+}
+
+///|
+fn table_value(size : Int) -> @gen.Gen[@toml.TomlValue] {
+  let next_size = size / 2
+  @gen.int_range(0, capped(size + 1, 4) + 1).bind(fn(count) {
+    entry(next_size)
+    .array_with_size(count)
+    .fmap(fn(entries) { TomlTable(Map::from_array(entries)) })
+  })
+}
+
+///|
+fn value(size : Int) -> @gen.Gen[@toml.TomlValue] {
+  let leaf = scalar_or_array(size)
+  if size <= 0 {
+    leaf
+  } else {
+    @gen.frequency([(9U, leaf), (2U, table_value(size))])
+  }
+}
+
+///|
+/// Generate a top-level TOML document (always a `TomlTable`) drawn from the
+/// round-trip-safe fragment. This is the reusable entry point: feed it to
+/// `@qc.forall_shrink` together with [`shrink_document`], or use the
+/// [`RoundTrippable`] newtype for the trait-driven runner.
+pub fn roundtrippable_document() -> @gen.Gen[@toml.TomlValue] {
+  @gen.sized(fn(size) {
+    @gen.int_range(0, capped(size + 1, 5) + 1).bind(fn(count) {
+      entry(size)
+      .array_with_size(count)
+      .fmap(fn(entries) { TomlTable(Map::from_array(entries)) })
+    })
+  })
+}

--- a/quickcheck/law.mbt
+++ b/quickcheck/law.mbt
@@ -1,0 +1,16 @@
+///|
+/// The round-trip law as a plain predicate: does `value` render and parse back
+/// to an equal value?
+///
+/// Parser errors are caught and reported as `false`, so this composes with any
+/// quickcheck runner without threading a `raise` effect through the property.
+/// For richer failure output (which key/value diverged), catch `@toml.parse`
+/// yourself and build a `Result[Unit, String]` counterexample instead.
+pub fn round_trips(value : @toml.TomlValue) -> Bool {
+  let rendered = value.to_string()
+  try @toml.parse(rendered) catch {
+    _ => false
+  } noraise {
+    parsed => parsed == value
+  }
+}

--- a/quickcheck/moon.pkg
+++ b/quickcheck/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "bobzhang/toml",
+  "bobzhang/toml/datetime",
+  "moonbitlang/quickcheck" @qc,
+  "moonbitlang/quickcheck/gen",
+  "moonbitlang/core/quickcheck" @core_qc,
+}

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -1,0 +1,37 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/toml/quickcheck"
+
+import {
+  "bobzhang/toml",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/quickcheck/splitmix",
+  "moonbitlang/quickcheck/gen",
+  "moonbitlang/quickcheck/shrink",
+}
+
+// Values
+pub fn round_trips(@toml.TomlValue) -> Bool
+
+pub fn roundtrippable_document() -> @gen.Gen[@toml.TomlValue]
+
+pub fn shrink_document(@toml.TomlValue) -> Iter[@toml.TomlValue]
+
+// Errors
+
+// Types and methods
+pub(all) struct RoundTrippable(@toml.TomlValue) derive(Eq, @debug.Debug)
+#deprecated
+pub fn RoundTrippable::arbitrary(Int, @splitmix.RandomState) -> Self
+pub fn RoundTrippable::equal(Self, Self) -> Bool
+pub fn RoundTrippable::inner(Self) -> @toml.TomlValue
+pub fn RoundTrippable::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn RoundTrippable::shrink(Self) -> Iter[Self]
+pub fn RoundTrippable::to_repr(Self) -> @debug.Repr
+pub impl @moonbitlang/core/quickcheck.Arbitrary for RoundTrippable
+pub impl @shrink.Shrink for RoundTrippable
+
+// Type aliases
+
+// Traits
+

--- a/quickcheck/pkg.generated.mbti
+++ b/quickcheck/pkg.generated.mbti
@@ -23,7 +23,6 @@ pub(all) struct RoundTrippable(@toml.TomlValue) derive(Eq, @debug.Debug)
 #deprecated
 pub fn RoundTrippable::arbitrary(Int, @splitmix.RandomState) -> Self
 pub fn RoundTrippable::equal(Self, Self) -> Bool
-pub fn RoundTrippable::inner(Self) -> @toml.TomlValue
 pub fn RoundTrippable::not_equal(Self, Self) -> Bool
 #deprecated
 pub fn RoundTrippable::shrink(Self) -> Iter[Self]

--- a/quickcheck/roundtrip_test.mbt
+++ b/quickcheck/roundtrip_test.mbt
@@ -6,7 +6,7 @@
 /// shrinker straight off the `RoundTrippable` instances, so the call names
 /// only the property.
 fn roundtrip_property(document : @quickcheck.RoundTrippable) -> @qc.Property {
-  let value = document.inner()
+  let value = document.0
   let rendered = value.to_string()
   check_roundtrip(value, rendered)
   |> @qc.classify(is_nested(value), "nested-table")

--- a/quickcheck/roundtrip_test.mbt
+++ b/quickcheck/roundtrip_test.mbt
@@ -1,0 +1,65 @@
+///|
+/// Property: every document from the round-trip-safe fragment survives
+/// `to_string` -> `@toml.parse` unchanged.
+///
+/// This is the trait-driven idiom — `quick_check_fn` pulls the generator and
+/// shrinker straight off the `RoundTrippable` instances, so the call names
+/// only the property.
+fn roundtrip_property(document : @quickcheck.RoundTrippable) -> @qc.Property {
+  let value = document.inner()
+  let rendered = value.to_string()
+  check_roundtrip(value, rendered)
+  |> @qc.classify(is_nested(value), "nested-table")
+  |> @qc.counterexample(rendered)
+}
+
+///|
+fn check_roundtrip(
+  value : @toml.TomlValue,
+  rendered : String,
+) -> Result[Unit, String] {
+  try @toml.parse(rendered) catch {
+    error => Err("parser rejected generated TOML\n\{rendered}\n---\n\{error}")
+  } noraise {
+    parsed =>
+      if parsed == value {
+        Ok(())
+      } else {
+        Err("round-trip mismatch\nrendered:\n\{rendered}\nparsed:\n\{parsed}")
+      }
+  }
+}
+
+///|
+fn is_nested(value : @toml.TomlValue) -> Bool {
+  match value {
+    TomlTable(fields) => fields.values().any(fn(v) { v is TomlTable(_) })
+    _ => false
+  }
+}
+
+///|
+test "round-trip law via quick_check_fn (trait-driven)" {
+  @qc.quick_check_fn_silence(roundtrip_property, max_success=500, max_size=10)
+  |> ignore
+}
+
+///|
+/// The same property expressed with the explicit-value idiom: hand the
+/// generator and shrinker to `forall_shrink` directly. Useful when a type has
+/// several generation strategies and no single canonical instance fits.
+test "round-trip law via forall_shrink (explicit generators)" {
+  @qc.quick_check_silence(
+    @qc.forall_shrink(
+      @quickcheck.roundtrippable_document(),
+      @quickcheck.shrink_document,
+      fn(value) {
+        let rendered = value.to_string()
+        check_roundtrip(value, rendered) |> @qc.counterexample(rendered)
+      },
+    ),
+    max_success=500,
+    max_size=10,
+  )
+  |> ignore
+}

--- a/quickcheck/roundtrippable.mbt
+++ b/quickcheck/roundtrippable.mbt
@@ -11,11 +11,13 @@
 /// ```mbt nocheck
 /// test {
 ///   @qc.quick_check_fn(fn(doc : @quickcheck.RoundTrippable) {
-///     let value = doc.inner()
-///     @toml.parse(value.to_string()) == value
+///     @toml.parse(doc.0.to_string()) == doc.0
 ///   })
 /// }
 /// ```
+///
+/// Access the wrapped value with the tuple-field accessor `.0` (or match
+/// `RoundTrippable(value)`), the same as the library's `modifiers`.
 pub(all) struct RoundTrippable(@toml.TomlValue) derive(Eq, Debug)
 
 ///|
@@ -23,13 +25,6 @@ pub extend RoundTrippable with Eq::{not_equal, equal}
 
 ///|
 pub extend RoundTrippable with Debug::{to_repr}
-
-///|
-/// Unwrap to the underlying `TomlValue`.
-pub fn RoundTrippable::inner(self : RoundTrippable) -> @toml.TomlValue {
-  let RoundTrippable(value) = self
-  value
-}
 
 ///|
 pub impl @core_qc.Arbitrary for RoundTrippable with fn arbitrary(size, rng) {
@@ -42,7 +37,7 @@ pub extend RoundTrippable with @core_qc.Arbitrary::{arbitrary}
 
 ///|
 pub impl @qc.Shrink for RoundTrippable with fn shrink(self) {
-  shrink_document(self.inner()).map(fn(value) { RoundTrippable(value) })
+  shrink_document(self.0).map(fn(value) { RoundTrippable(value) })
 }
 
 ///|

--- a/quickcheck/roundtrippable.mbt
+++ b/quickcheck/roundtrippable.mbt
@@ -1,0 +1,50 @@
+///|
+/// A `TomlValue` drawn from the round-trip-safe fragment, wrapped so it can
+/// carry the quickcheck trait instances.
+///
+/// A companion package cannot implement the foreign `@core_qc.Arbitrary` /
+/// `@qc.Shrink` traits directly on the foreign `@toml.TomlValue` (orphan
+/// rule), so we wrap it in a local newtype — the same pattern the quickcheck
+/// library uses for its own modifiers (`Positive`, `NonEmptyArray`, ...).
+/// With the instances attached, downstream tests get the ergonomic runner:
+///
+/// ```mbt nocheck
+/// test {
+///   @qc.quick_check_fn(fn(doc : @quickcheck.RoundTrippable) {
+///     let value = doc.inner()
+///     @toml.parse(value.to_string()) == value
+///   })
+/// }
+/// ```
+pub(all) struct RoundTrippable(@toml.TomlValue) derive(Eq, Debug)
+
+///|
+pub extend RoundTrippable with Eq::{not_equal, equal}
+
+///|
+pub extend RoundTrippable with Debug::{to_repr}
+
+///|
+/// Unwrap to the underlying `TomlValue`.
+pub fn RoundTrippable::inner(self : RoundTrippable) -> @toml.TomlValue {
+  let RoundTrippable(value) = self
+  value
+}
+
+///|
+pub impl @core_qc.Arbitrary for RoundTrippable with fn arbitrary(size, rng) {
+  RoundTrippable(roundtrippable_document().run(size, rng))
+}
+
+///|
+#deprecated("resolve through the Arbitrary trait, e.g. via @qc.quick_check_fn")
+pub extend RoundTrippable with @core_qc.Arbitrary::{arbitrary}
+
+///|
+pub impl @qc.Shrink for RoundTrippable with fn shrink(self) {
+  shrink_document(self.inner()).map(fn(value) { RoundTrippable(value) })
+}
+
+///|
+#deprecated("resolve through the Shrink trait")
+pub extend RoundTrippable with @qc.Shrink::{shrink}

--- a/quickcheck/shrink.mbt
+++ b/quickcheck/shrink.mbt
@@ -1,0 +1,68 @@
+///|
+/// Shrinkers for the round-trip-safe fragment.
+///
+/// `TomlValue` has no `@qc.Shrink` instance of its own (a companion package
+/// can't add one — orphan rule), so these are plain functions. They pair with
+/// [`roundtrippable_document`] under `@qc.forall_shrink`, and back the
+/// `@qc.Shrink` impl on [`RoundTrippable`].
+
+///|
+fn[T] drop_each(items : Array[T]) -> Iter[Array[T]] {
+  Array::makei(items.length(), fn(i) {
+    let next = items.copy()
+    next.remove(i) |> ignore
+    next
+  }).iter()
+}
+
+///|
+fn shrink_value(value : @toml.TomlValue) -> Iter[@toml.TomlValue] {
+  match value {
+    TomlString(s) => @qc.Shrink::shrink(s).map(fn(next) { TomlString(next) })
+    TomlInteger(n) => @qc.Shrink::shrink(n).map(fn(next) { TomlInteger(next) })
+    TomlBoolean(b) => @qc.Shrink::shrink(b).map(fn(next) { TomlBoolean(next) })
+    // Atomic in this fragment: datetimes don't shrink, and floats are never
+    // generated (kept here only for match exhaustiveness).
+    TomlDateTime(_) | TomlFloat(_) => Iter::empty()
+    // Arrays shrink by dropping elements (which preserves homogeneity);
+    // an emptied array is still round-trippable.
+    TomlArray(items) => drop_each(items).map(fn(next) { TomlArray(next) })
+    TomlTable(fields) =>
+      shrink_entries(fields.to_array()).map(fn(next) {
+        TomlTable(Map::from_array(next))
+      })
+  }
+}
+
+///|
+fn shrink_entries(
+  entries : Array[(String, @toml.TomlValue)],
+) -> Iter[Array[(String, @toml.TomlValue)]] {
+  let removed = drop_each(entries)
+  let shrunk_values = Array::makei(entries.length(), fn(i) {
+      let (key, value) = entries[i]
+      shrink_value(value)
+      .map(fn(next_value) {
+        let next = entries.copy()
+        next[i] = (key, next_value)
+        next
+      })
+      .to_array()
+    })
+    .flatten()
+    .iter()
+  removed.concat(shrunk_values)
+}
+
+///|
+/// Shrink a top-level document toward smaller failing cases by removing table
+/// entries and simplifying individual values.
+pub fn shrink_document(document : @toml.TomlValue) -> Iter[@toml.TomlValue] {
+  match document {
+    TomlTable(fields) =>
+      shrink_entries(fields.to_array()).map(fn(next) {
+        TomlTable(Map::from_array(next))
+      })
+    _ => Iter::empty()
+  }
+}


### PR DESCRIPTION
Implements **Option C** from the RFC in #115 — a companion package that exposes
reusable quickcheck support for `TomlValue` while keeping the core parser free
of any quickcheck dependency. Parse-only consumers pay nothing; only importers
of `bobzhang/toml/quickcheck` take on `moonbitlang/quickcheck` and its
transitive weight.

## The design constraint (why a newtype, not `impl Arbitrary for TomlValue`)

A companion package **cannot** implement `Arbitrary`/`Shrink` directly on
`TomlValue`: both the traits (`moonbitlang/core/quickcheck`,
`moonbitlang/quickcheck/shrink`) and the type (`bobzhang/toml`) are *foreign*
to it, so the impl violates the orphan rule (compiler error 4061). Only core
itself (Option B) could add a bare impl — at the cost of pulling quickcheck into
core's runtime deps.

The idiomatic escape hatch is the same one `moonbitlang/quickcheck`'s own
`modifiers` package uses (`Positive`, `NonEmptyArray`, ...): wrap the value in a
**local** newtype that carries the trait instances.

## Public API

```
pub fn roundtrippable_document() -> @gen.Gen[@toml.TomlValue]  // safe fragment
pub fn shrink_document(@toml.TomlValue) -> Iter[@toml.TomlValue]
pub fn round_trips(@toml.TomlValue) -> Bool                    // parse(v.to_string()) == v
pub(all) struct RoundTrippable(@toml.TomlValue)                // + Arbitrary + Shrink impls
```

The generated fragment covers every primitive, homogeneous arrays, nested
tables, and adversarial keys (quoted, dotted, and negative-exponent-like keys
that collide with the float grammar). It deliberately **excludes** floats and
mixed-type arrays so that exact `==` after a round-trip is meaningful.

## Two idioms shown

**Trait-driven** — `quick_check_fn` reads the generator/shrinker off the newtype:

```moonbit
@qc.quick_check_fn(fn(doc : @quickcheck.RoundTrippable) {
  @quickcheck.round_trips(doc.inner())
}, max_success=100)
```

**Explicit generators** — hand them to `forall_shrink` directly:

```moonbit
@qc.quick_check(@qc.forall_shrink(
  @quickcheck.roundtrippable_document(),
  @quickcheck.shrink_document,
  fn(value) { @quickcheck.round_trips(value) },
), max_success=100)
```

## Notes

- `RoundTrippable` mirrors the internal `qc_model` `SimpleValue` proxy, but as a
  newtype over the *real* `TomlValue` rather than a parallel type + conversions
  — a possible path to retiring that proxy later (not done here).
- Trade-off to keep in mind: round-trip safety now lives in the *generator*
  rather than in a restricted type, so the fragment is a convention, not a
  type-level guarantee. This is a fuzzing/law generator, not a full-`TomlValue`
  Arbitrary (floats/mixed arrays are out of scope by design).

## Testing

- New package: 4 tests (trait-driven + explicit idioms, plus two README
  doc-tests), 500 cases each in the test file.
- `moon check` clean (zero warnings), `moon fmt`, `moon info` committed.
- Full workspace suite: **413 passed**.

Closes the implementation side of #115 (the decision itself is still open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
