### PR TITLE
fix: clear moonc 0.10.5 warnings in qc_model and tokenize

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -68,6 +68,7 @@ moon add bobzhang/toml
 Then add it directly to your `moon.mod`:
 
 ```moonbit nocheck
+///|
 import {
   "bobzhang/toml@0.2.3",
 }

--- a/internal/qc_model/model.mbt
+++ b/internal/qc_model/model.mbt
@@ -40,30 +40,12 @@ pub extend SimpleDocument with Eq::{not_equal, equal}
 pub extend SimpleDocument with Debug::{to_repr}
 
 ///|
-#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
-pub extend SimpleDocument with Show::{to_string, output}
-
-///|
 #deprecated("compare with `==`; the Eq impl is unaffected")
 pub extend SimpleValue with Eq::{not_equal, equal}
 
 ///|
 #deprecated("render via the Debug trait, e.g. `debug_inspect`")
 pub extend SimpleValue with Debug::{to_repr}
-
-///|
-#deprecated("render via the Show trait, e.g. `inspect` or `\\{value}`")
-pub extend SimpleValue with Show::{to_string, output}
-
-///|
-pub impl Show for SimpleDocument with fn output(self, logger) {
-  Debug::to_repr(self).output(logger)
-}
-
-///|
-pub impl Show for SimpleValue with fn output(self, logger) {
-  Debug::to_repr(self).output(logger)
-}
 
 ///|
 /// Lift a model value into the parser's `TomlValue` representation.

--- a/internal/qc_model/pkg.generated.mbti
+++ b/internal/qc_model/pkg.generated.mbti
@@ -29,13 +29,8 @@ pub fn SimpleDocument::from_toml(@toml.TomlValue) -> Self?
 #deprecated
 pub fn SimpleDocument::not_equal(Self, Self) -> Bool
 #deprecated
-pub fn SimpleDocument::output(Self, &Logger) -> Unit
-#deprecated
 pub fn SimpleDocument::to_repr(Self) -> @debug.Repr
-#deprecated
-pub fn SimpleDocument::to_string(Self) -> String
 pub fn SimpleDocument::to_toml(Self) -> @toml.TomlValue
-pub impl Show for SimpleDocument
 
 pub(all) enum SimpleValue {
   SString(String)
@@ -55,13 +50,8 @@ pub fn SimpleValue::from_toml(@toml.TomlValue) -> Self?
 #deprecated
 pub fn SimpleValue::not_equal(Self, Self) -> Bool
 #deprecated
-pub fn SimpleValue::output(Self, &Logger) -> Unit
-#deprecated
 pub fn SimpleValue::to_repr(Self) -> @debug.Repr
-#deprecated
-pub fn SimpleValue::to_string(Self) -> String
 pub fn SimpleValue::to_toml(Self) -> @toml.TomlValue
-pub impl Show for SimpleValue
 
 // Type aliases
 

--- a/internal/qc_model/roundtrip_test.mbt
+++ b/internal/qc_model/roundtrip_test.mbt
@@ -16,7 +16,7 @@ fn simple_document_roundtrip_check(
             Ok(())
           } else {
             Err(
-              "round-trip mismatch\nrendered:\n\{rendered}\noriginal:\n\{doc}\nparsed:\n\{roundtripped}",
+              "round-trip mismatch\nrendered:\n\{rendered}\noriginal:\n\{repr(doc)}\nparsed:\n\{repr(roundtripped)}",
             )
           }
         None =>

--- a/internal/tokenize/lexer_test.mbt
+++ b/internal/tokenize/lexer_test.mbt
@@ -1631,7 +1631,7 @@ test "test hex overflow edge case" {
       value => Ok(value)
     },
     content=(
-      #|Err(Failure("internal/tokenize/tokenize.mbt:555:7-555:71@bobzhang/toml FAILED: Invalid hex number: value out of Int64 range at line 1, column 7"))
+      #|Err(Failure("internal/tokenize/tokenize.mbt:559:7-559:71@bobzhang/toml FAILED: Invalid hex number: value out of Int64 range at line 1, column 7"))
     ),
   )
 }

--- a/internal/tokenize/tokenize.mbt
+++ b/internal/tokenize/tokenize.mbt
@@ -1,7 +1,11 @@
 ///|
 /// Default location for testing and compatibility
 pub fn default_loc() -> Loc {
-  let pos : @lexer.Position = { line: 1, column: 1 }
+  // FIXME(upstream): two lints disagree, so the type is spelled exactly once.
+  // `let pos : @lexer.Position = { ... }` trips unqualified_record, while
+  // spelling both the annotation and the `T::` prefix trips
+  // unnecessary_annotation.
+  let pos = @lexer.Position::{ line: 1, column: 1 }
   { start: pos, end: pos }
 }
 


### PR DESCRIPTION
## Summary

The current toolchain (moonc v0.10.5) surfaces two warnings on a clean checkout of `main`. Both live in code that exists only to serve tests, so this clears them by **removing plumbing rather than adding suppressions**.

```
internal/tokenize/tokenize.mbt:4  [E0084] unqualified_record
internal/qc_model/model.mbt:60    [E0020] deprecated: Repr::output
internal/qc_model/model.mbt:65    [E0020] deprecated: Repr::output
```

## `qc_model`: drop `Show`, keep `Debug`

`impl Show` for `SimpleDocument`/`SimpleValue` forwarded to `Debug::to_repr(self).output(logger)`, and `Repr::output` is now deprecated in favour of rendering through `Show`/`to_string`.

Rather than rewrite the forwarding, the impls go away entirely. Both types already `derive(Debug)`, and the sole consumer was one `\{doc}` interpolation in the round-trip failure message:

```diff
-"round-trip mismatch\n...\noriginal:\n\{doc}\nparsed:\n\{roundtripped}"
+"round-trip mismatch\n...\noriginal:\n\{repr(doc)}\nparsed:\n\{repr(roundtripped)}"
```

`repr` is the idiomatic Debug rendering and a closer match to what the impl was producing anyway, so failure output is unchanged in spirit. The package is `internal/`, so there is no downstream break.

**The `#deprecated` Eq/Debug `extend` shims stay.** They are the downstream warning window deliberately opened in 9f1de25 and are unrelated to this warning — only the `Show::{to_string, output}` promotions go, alongside the impls they promoted. Net: 18 lines removed from `model.mbt`, 10 from the generated `.mbti`.

## `tokenize`: spell the type exactly once

`let pos : @lexer.Position = { line: 1, column: 1 }` trips `unqualified_record`. The two lints here genuinely disagree — verified both directions:

| form | result |
|---|---|
| `let pos : @lexer.Position = { ... }` | `[E0084] unqualified_record` |
| `let pos : @lexer.Position = @lexer.Position::{ ... }` | `[E0073] unnecessary_annotation` |
| `let pos = @lexer.Position::{ ... }` | clean |

The last form is used, with a `FIXME(upstream)` recording why the annotation is absent. Those added lines shift a source location embedded in the hex-overflow snapshot, hence the `555` → `559` update in `lexer_test.mbt` — no behaviour change.

## Second commit: README formatting

CI runs `moon fmt && git diff --exit-code`, and **that step already fails on a clean checkout of `main`**: the current `moon fmt` formats the ` ```moonbit nocheck ` installation block as MoonBit source and adds a `///|` above the `import`. This commit takes the formatter's output as-is.

Pre-existing and independent of the warning fixes — kept as a separate commit, included so this branch's CI is green.

## Verification

Every CI step run locally:

- `moon fmt` — idempotent on a clean tree
- `moon info` — idempotent
- `moon check --deny-warn` — clean
- `moon test` — 411 passed, 0 failed
- `moon test e2e --target native` — 15 passed, 0 failed
- `moon -C toml_cli cram test --release tests/cram` — 6 succeeded, 0 failed

The `474 passed, 9 failed out of 483 invalid tests` line in the conformance output is the recorded toml-test baseline inside a passing expect test — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)