### PR TITLE
fix: clear moonc 0.10.6 guard_inexhaustive warnings

### DIFF
--- a/datetime/pkg.generated.mbti
+++ b/datetime/pkg.generated.mbti
@@ -30,4 +30,3 @@ pub impl Show for TomlDateTime
 // Type aliases
 
 // Traits
-

--- a/e2e/pkg.generated.mbti
+++ b/e2e/pkg.generated.mbti
@@ -30,4 +30,3 @@ pub fn TestResult::new() -> Self
 // Type aliases
 
 // Traits
-

--- a/internal/qc_model/pkg.generated.mbti
+++ b/internal/qc_model/pkg.generated.mbti
@@ -56,4 +56,3 @@ pub fn SimpleValue::to_toml(Self) -> @toml.TomlValue
 // Type aliases
 
 // Traits
-

--- a/internal/tokenize/pkg.generated.mbti
+++ b/internal/tokenize/pkg.generated.mbti
@@ -59,4 +59,3 @@ pub fn Token::to_repr(Self) -> @debug.Repr
 // Type aliases
 
 // Traits
-

--- a/lexer/pkg.generated.mbti
+++ b/lexer/pkg.generated.mbti
@@ -34,4 +34,3 @@ pub(all) struct Position {
 // Type aliases
 
 // Traits
-

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub impl Show for TomlValue
 pub using @datetime {type TomlDateTime}
 
 // Traits
-

--- a/toml_cli/pkg.generated.mbti
+++ b/toml_cli/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/toml_cli"
 // Type aliases
 
 // Traits
-

--- a/toml_test.mbt
+++ b/toml_test.mbt
@@ -343,10 +343,14 @@ test "datetime token creation" {
   let local_time_token = @tokenize.DateTimeToken(LocalTime("07:32:00"), loc~)
 
   // Test that tokens can be created (basic instantiation test)
-  guard offset_dt_token is DateTimeToken(OffsetDateTime("1979-05-27T07:32:00Z"))
-  guard local_dt_token is DateTimeToken(LocalDateTime("1979-05-27T07:32:00"))
-  guard local_date_token is DateTimeToken(LocalDate("1979-05-27"))
-  guard local_time_token is DateTimeToken(LocalTime("07:32:00"))
+  assert_true(
+    offset_dt_token is DateTimeToken(OffsetDateTime("1979-05-27T07:32:00Z")),
+  )
+  assert_true(
+    local_dt_token is DateTimeToken(LocalDateTime("1979-05-27T07:32:00")),
+  )
+  assert_true(local_date_token is DateTimeToken(LocalDate("1979-05-27")))
+  assert_true(local_time_token is DateTimeToken(LocalTime("07:32:00")))
 }
 
 ///|

--- a/toml_utils.mbt
+++ b/toml_utils.mbt
@@ -436,7 +436,9 @@ fn set_dotted_key_value(
   value : TomlValue,
   mark_implicit? : Bool = false,
 ) -> Unit raise TableConflicts {
-  guard key_path.length() != 0
+  guard key_path.length() != 0 else {
+    abort("set_dotted_key_value: key_path must not be empty")
+  }
   if key_path.length() == 1 {
     // Simple key assignment — reject duplicates
     let key = key_path[0]


### PR DESCRIPTION
## Summary
- Replace the four bare `guard ... is` pattern assertions in the datetime token test with `assert_true(... is ...)`, which fails the test cleanly instead of panicking and satisfies the new `guard_inexhaustive` (warning 87) check.
- Give the empty-`key_path` guard in `set_dotted_key_value` an explicit `else { abort(...) }` branch with a descriptive message, since an empty path there is an internal invariant violation.

Both forms are backward compatible with older moonc releases (no `guard!` syntax used), so CI on the stable channel is unaffected.

## Test plan
- `moon check` — 0 warnings (was 5 on moonc 0.10.6)
- `moon fmt` / `moon info` — no diff
- `moon test` — 411 passed, 0 failed
- `moon test e2e --target native` — 15 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)