### PR TITLE
feat(toml_cli): add tojson subcommand

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -85,6 +85,7 @@ straight through, no `--` separator):
 moonx bobzhang/toml_cli --help
 moonx bobzhang/toml_cli check config.toml
 moonx bobzhang/toml_cli format config.toml
+moonx bobzhang/toml_cli tojson config.toml
 ```
 
 Or run it from source in this repository:

--- a/toml_cli/README.md
+++ b/toml_cli/README.md
@@ -22,9 +22,14 @@ moonx bobzhang/toml_cli format config.toml
 toml <file>           Parse TOML and print normalized TOML (same as `format`)
 toml format <file>    Parse TOML and print normalized TOML
 toml check <file>     Validate TOML without printing parsed output
+toml tojson <file>    Parse TOML and print it as JSON
 ```
 
 Exit codes: `0` on success, `1` on read/parse failure, `2` on usage errors.
+
+`tojson` maps tables to objects and arrays to arrays; datetimes become their
+TOML string form, integers keep their exact 64-bit decimal representation,
+and non-finite floats become the strings `"nan"`/`"inf"`/`"-inf"`.
 
 ## Run from source
 

--- a/toml_cli/main.mbt
+++ b/toml_cli/main.mbt
@@ -10,6 +10,7 @@ let about : String =
   #|
   #|  moonx bobzhang/toml_cli check config.toml
   #|  moonx bobzhang/toml_cli format config.toml
+  #|  moonx bobzhang/toml_cli tojson config.toml
   #|
   #|Exit codes:
   #|  0  success
@@ -46,6 +47,13 @@ fn toml_command() -> @argparse.Command {
           num_args=@argparse.ValueRange::single(),
         ),
       ]),
+      Command("tojson", about="Parse TOML and print it as JSON.", positionals=[
+        PositionArg(
+          "file",
+          about="TOML file to convert.",
+          num_args=@argparse.ValueRange::single(),
+        ),
+      ]),
     ],
   )
 }
@@ -69,6 +77,7 @@ fn run(args : ArrayView[String]) -> Int {
   match matches.subcommand {
     Some(("format", child)) => dispatch_file(child, format_file)
     Some(("check", child)) => dispatch_file(child, check_file)
+    Some(("tojson", child)) => dispatch_file(child, tojson_file)
     Some((name, _)) => {
       println("error: unsupported command `\{name}`")
       2

--- a/toml_cli/tests/cram/toml_cli.md
+++ b/toml_cli/tests/cram/toml_cli.md
@@ -25,6 +25,7 @@ cached on first use; pin a version with bobzhang/toml_cli@<version>):
 
   moonx bobzhang/toml_cli check config.toml
   moonx bobzhang/toml_cli format config.toml
+  moonx bobzhang/toml_cli tojson config.toml
 
 Exit codes:
   0  success
@@ -39,6 +40,7 @@ move it over the original after checking the exit code.
 Commands:
   format  Parse TOML and print normalized TOML.
   check   Validate TOML without printing parsed output.
+  tojson  Parse TOML and print it as JSON.
   help    Print help for the subcommand(s).
 
 Arguments:
@@ -60,6 +62,7 @@ cached on first use; pin a version with bobzhang/toml_cli@<version>):
 
   moonx bobzhang/toml_cli check config.toml
   moonx bobzhang/toml_cli format config.toml
+  moonx bobzhang/toml_cli tojson config.toml
 
 Exit codes:
   0  success
@@ -74,6 +77,7 @@ move it over the original after checking the exit code.
 Commands:
   format  Parse TOML and print normalized TOML.
   check   Validate TOML without printing parsed output.
+  tojson  Parse TOML and print it as JSON.
   help    Print help for the subcommand(s).
 
 Arguments:
@@ -112,6 +116,38 @@ $ cat > valid.toml <<'EOF'
 > EOF
 > toml_cli.exe check valid.toml
 valid.toml: OK
+```
+
+## Convert To JSON
+
+Integers keep their exact 64-bit decimal representation (note `big` below
+is 2^53 + 1, which a double cannot represent), and datetimes become their
+TOML string form:
+
+```mooncram
+$ cat > convert.toml <<'EOF'
+> title = "MoonBit"
+> ports = [8000, 8001]
+> pi = 3.14
+> big = 9007199254740993
+> date = 1979-05-27T07:32:00Z
+> [server]
+> enabled = true
+> EOF
+> toml_cli.exe tojson convert.toml
+{
+  "title": "MoonBit",
+  "ports": [
+    8000,
+    8001
+  ],
+  "pi": 3.14,
+  "big": 9007199254740993,
+  "date": "1979-05-27T07:32:00Z",
+  "server": {
+    "enabled": true
+  }
+}
 ```
 
 ## Report Parse Errors

--- a/toml_cli/tojson.mbt
+++ b/toml_cli/tojson.mbt
@@ -1,0 +1,46 @@
+///|
+/// Convert a parsed TOML document to a plain JSON value: tables become
+/// objects, arrays stay arrays, and datetimes become their TOML string
+/// form. Integers keep their exact 64-bit decimal representation, and
+/// non-finite floats become the strings "nan"/"inf"/"-inf" since JSON
+/// cannot represent them as numbers.
+fn to_json(value : @toml_lib.TomlValue) -> Json {
+  match value {
+    TomlString(s) => Json::string(s)
+    TomlInteger(i) => Json::number(i.to_double(), repr=i.to_string())
+    TomlFloat(f) =>
+      if f.is_nan() {
+        Json::string("nan")
+      } else if f.is_inf() {
+        Json::string(if f < 0.0 { "-inf" } else { "inf" })
+      } else {
+        Json::number(f)
+      }
+    TomlBoolean(b) => Json::boolean(b)
+    TomlDateTime(_) => {
+      let (_, s) = value.datetime_info().unwrap()
+      Json::string(s)
+    }
+    TomlArray(arr) => Json::array([ for v in arr => to_json(v) ])
+    TomlTable(table) =>
+      Json::object(Map::from_array([ for k, v in table => (k, to_json(v)) ]))
+  }
+}
+
+///|
+fn tojson_file(path : String) -> Int {
+  let source = @fs.read_file_to_string(path) catch {
+    err => {
+      println("error: failed to read \{path}: \{err}")
+      return 1
+    }
+  }
+  let value = @toml_lib.parse(source) catch {
+    err => {
+      println("error: failed to parse \{path}: \{err}")
+      return 1
+    }
+  }
+  println(to_json(value).stringify(indent=2))
+  0
+}


### PR DESCRIPTION
## Summary
- New `tojson` subcommand: `moonx bobzhang/toml_cli tojson config.toml` parses a TOML file and prints it as plain JSON with 2-space indent (tables → objects, arrays → arrays, datetimes → their TOML string form).
- Integers keep their exact 64-bit decimal representation via `Json::number`'s `repr~` parameter (the cram test covers 2^53 + 1, which a double cannot represent), and non-finite floats become the strings `"nan"`/`"inf"`/`"-inf"` since JSON has no encoding for them.
- Exit codes match `check`/`format`: 0 success, 1 read/parse failure, 2 usage error.
- `--help`, both READMEs, and the cram transcripts document the new subcommand.

The CLI version stays at 0.1.0; bump it at the next mooncakes publish.

## Test plan
- `moon -C toml_cli cram test --release tests/cram` — 7/7 pass (new Convert To JSON transcript)
- `moon check` / `moon fmt` / `moon info` — clean, no public API change
- `moon test` — 411 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)