### PR TITLE
chore(toml_cli): bump to 0.2.0 for the tojson subcommand

### DIFF
--- a/toml_cli/main.mbt
+++ b/toml_cli/main.mbt
@@ -1,5 +1,5 @@
 ///|
-let version : String = "0.1.0"
+let version : String = "0.2.0"
 
 ///|
 let about : String =

--- a/toml_cli/moon.mod
+++ b/toml_cli/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/toml_cli"
 
-version = "0.1.0"
+version = "0.2.0"
 
 import {
   "bobzhang/toml@0.4.2",

--- a/toml_cli/tests/cram/toml_cli.md
+++ b/toml_cli/tests/cram/toml_cli.md
@@ -11,7 +11,7 @@ moon cram test --release tests/cram
 
 ```mooncram
 $ toml_cli.exe --version
-0.1.0
+0.2.0
 ```
 
 ```mooncram


### PR DESCRIPTION
## Summary
Bump `bobzhang/toml_cli` 0.1.0 → 0.2.0 (new `tojson` subcommand landed in #120) ahead of publishing to mooncakes.io. Updates `moon.mod`, the CLI's `--version` string, and the cram expectation.

## Test plan
- `moon -C toml_cli cram test --release tests/cram` — 7/7 pass
- `moon check` / `moon fmt` / `moon info` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)